### PR TITLE
make it so parsing features can be turned on and off with configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .nyc_output
 node_modules
 .DS_Store
+./test/fixtures/package.json

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 node_modules
 .DS_Store
 yargs-logo.png
+./test/fixtures/package.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
+os:
+  - linux
+  - osx
 node_js:
   - "0.10"
   - "0.12"
+  - "0.8"
+  - "4.1"
   - "node"
 after_script: npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: node_js
 os:
   - linux
-  - osx
 node_js:
   - "0.10"
   - "0.12"
-  - "0.8"
   - "4.1"
   - "node"
 after_script: npm run coverage

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ yargs engine.
 * `error`: populated with an error object if an exception occurred during parsing.
 * `aliases`: the inferred list of aliases built by combining lists in `opts.alias`.
 * `newAliases`: any new aliases added via camel-case expansion.
+* `configuration`: the configuration loaded from the `yargs` stanza in package.json.
 
 ### Configuration
 
@@ -119,7 +120,7 @@ node example.js -abc
 ### camel-case expansion
 
 * default: `true`.
-* key: `camel-case`.
+* key: `camel-case-expansion`.
 
 Should hyphenated arguments be expanded into camel-case aliases?
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/yargs/yargs-parser.png)](https://travis-ci.org/yargs/yargs-parser)
 [![Coverage Status](https://coveralls.io/repos/yargs/yargs-parser/badge.svg?branch=)](https://coveralls.io/r/yargs/yargs-parser?branch=master)
 [![NPM version](https://img.shields.io/npm/v/yargs-parser.svg)](https://www.npmjs.com/package/yargs-parser)
-[![Windows Tests](https://img.shields.io/appveyor/ci/yargs/yargs-parser/master.svg?label=Windows%20Tests)](https://ci.appveyor.com/project/yargs/yargs-parser)
+[![Windows Tests](https://img.shields.io/appveyor/ci/bcoe/yargs-parser/master.svg?label=Windows%20Tests)](https://ci.appveyor.com/project/bcoe/yargs-parser)
 
 The mighty option parser used by yargs.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![NPM version](https://img.shields.io/npm/v/yargs-parser.svg)](https://www.npmjs.com/package/yargs-parser)
 [![Windows Tests](https://img.shields.io/appveyor/ci/bcoe/yargs-parser/master.svg?label=Windows%20Tests)](https://ci.appveyor.com/project/bcoe/yargs-parser)
 
-The mighty option parser used by yargs.
+The mighty option parser used by [yargs](https://github.com/bcoe/yargs).
+
+visit the [yargs website](http://yargs.js.org/) for more examples, and thorough usage instructions.
 
 <img width="250" src="yargs-logo.png">
 

--- a/example.js
+++ b/example.js
@@ -1,2 +1,3 @@
-var argv = require('./')(process.argv.slice(2))
-console.log(argv)
+var parser = require('./')
+var parse = parser(['-cats', 'meow'])
+console.log(parse)

--- a/index.js
+++ b/index.js
@@ -302,7 +302,7 @@ function parse (args, opts) {
       if (typeof val === 'string') val = val === 'true'
     }
 
-    if (/-/.test(key) && !(flags.aliases[key] && flags.aliases[key].length)) {
+    if (/-/.test(key) && !(flags.aliases[key] && flags.aliases[key].length) && configuration['camel-case-expansion']) {
       var c = camelCase(key)
       flags.aliases[key] = [c]
       newAliases[c] = true

--- a/index.js
+++ b/index.js
@@ -443,6 +443,9 @@ function parse (args, opts) {
 
   function setKey (obj, keys, value) {
     var o = obj
+
+    if (!configuration['dot-notation']) keys = [keys.join('.')]
+
     keys.slice(0, -1).forEach(function (key) {
       if (o[key] === undefined) o[key] = {}
       o = o[key]
@@ -555,7 +558,8 @@ function loadConfiguration () {
   var pkg = readPkgUp.sync({cwd: path.dirname(parentModule)}).pkg
   return assign({
     'short-option-groups': true,
-    'camel-case-expansion': true
+    'camel-case-expansion': true,
+    'dot-notation': true
   }, pkg.yargs)
 }
 

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function parse (args, opts) {
       } else {
         setArg(m[1], m[2])
       }
-    } else if (arg.match(/^--no-.+/)) {
+    } else if (arg.match(/^--no-.+/) && configuration['boolean-negation']) {
       key = arg.match(/^--no-(.+)/)[1]
       setArg(key, false)
 
@@ -539,6 +539,7 @@ function parse (args, opts) {
   }
 
   function isNumber (x) {
+    if (!configuration['parse-numbers']) return false
     if (typeof x === 'number') return true
     if (/^0x[0-9a-f]+$/i.test(x)) return true
     return /^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(x)
@@ -554,17 +555,16 @@ function parse (args, opts) {
 }
 
 function loadConfiguration (cwd) {
-  var defaults = {
-    'short-option-groups': true,
-    'camel-case-expansion': true,
-    'dot-notation': true
-  }
-  var conf = pkgConf.sync('yargs', {
-    defaults: defaults,
+  return pkgConf.sync('yargs', {
+    defaults: {
+      'short-option-groups': true,
+      'camel-case-expansion': true,
+      'dot-notation': true,
+      'parse-numbers': true,
+      'boolean-negation': true
+    },
     cwd: findUp.sync('package.json', {cwd: cwd})
   })
-  if (!Object.keys(conf).length) return defaults
-  else return conf
 }
 
 // if any aliases reference each other, we should

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
-var assign = require('lodash.assign')
 var camelCase = require('camelcase')
+var pkgConf = require('pkg-conf')
 var path = require('path')
 var parentModule = require('parent-module')
-var readPkgUp = require('read-pkg-up')
 var tokenizeArgString = require('./lib/tokenize-arg-string')
 var util = require('util')
 
@@ -555,12 +554,14 @@ function parse (args, opts) {
 }
 
 function loadConfiguration () {
-  var pkg = readPkgUp.sync({cwd: path.dirname(parentModule)}).pkg
-  return assign({
-    'short-option-groups': true,
-    'camel-case-expansion': true,
-    'dot-notation': true
-  }, pkg.yargs)
+  return pkgConf.sync('yargs', {
+    defaults: {
+      'short-option-groups': true,
+      'camel-case-expansion': true,
+      'dot-notation': true
+    },
+    cwd: path.dirname(parentModule)
+  })
 }
 
 // if any aliases reference each other, we should

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   "dependencies": {
     "camelcase": "^2.0.1",
     "find-up": "^1.1.0",
-    "pkg-conf": "^1.1.0"
+    "pkg-conf": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   },
   "dependencies": {
     "camelcase": "^2.0.1",
-    "lodash.assign": "^4.0.0",
     "parent-module": "^0.1.0",
-    "read-pkg-up": "^1.0.1"
+    "pkg-conf": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,13 @@
     "coveralls": "^2.11.6",
     "mocha": "^2.3.4",
     "nyc": "^5.3.0",
+    "rimraf": "^2.5.1",
     "standard": "^5.4.1"
   },
   "dependencies": {
-    "camelcase": "^2.0.1"
+    "camelcase": "^2.0.1",
+    "lodash.assign": "^4.0.0",
+    "parent-module": "^0.1.0",
+    "read-pkg-up": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "camelcase": "^2.0.1",
-    "parent-module": "^0.1.0",
+    "find-up": "^1.1.0",
     "pkg-conf": "^1.1.0"
   }
 }

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1477,16 +1477,10 @@ describe('yargs-parser', function () {
       })
 
       it('does not expand camel-case keys', function () {
-        var parsed = parser.detailed(['--foo-bar=apple'], {
-          alias: {
-            'foo-bar': ['cool-stuff']
-          }
-        })
+        var parsed = parser.detailed(['--foo-bar=apple'])
 
         expect(parsed.argv.fooBar).to.equal(undefined)
-        expect(parsed.argv.coolStuff).to.equal(undefined)
         expect(parsed.argv['foo-bar']).to.equal('apple')
-        expect(parsed.argv['cool-stuff']).to.equal('apple')
       })
     })
   })

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1,4 +1,4 @@
-/* global before, beforeEach, describe, it, afterEach */
+/* global beforeEach, describe, it, afterEach */
 
 require('chai').should()
 
@@ -1412,18 +1412,11 @@ describe('yargs-parser', function () {
   })
 
   describe('configuration', function () {
-    var cwd = null
-
-    before(function () {
-      cwd = process.cwd()
-    })
-
     beforeEach(function () {
       rimraf.sync('./test/fixtures/package.json')
     })
 
     afterEach(function () {
-      process.chdir(cwd)
       rimraf.sync('./test/fixtures/package.json')
     })
 
@@ -1433,9 +1426,10 @@ describe('yargs-parser', function () {
           'short-option-groups': false
         }
       }), 'utf-8')
-      process.chdir('./test/fixtures/inner')
 
-      var result = parser.detailed([])
+      var result = parser.detailed([], {
+        cwd: './test/fixtures/inner'
+      })
       result.configuration['short-option-groups'].should.equal(false)
     })
 
@@ -1446,11 +1440,14 @@ describe('yargs-parser', function () {
             'short-option-groups': false
           }
         }), 'utf-8')
-        process.chdir('./test/fixtures/inner')
 
-        var parse = parser(['-cats=meow'])
+        var parse = parser(['-cats=meow'], {
+          cwd: './test/fixtures/inner'
+        })
         parse.cats.should.equal('meow')
-        parse = parser(['-cats', 'meow'])
+        parse = parser(['-cats', 'meow'], {
+          cwd: './test/fixtures/inner'
+        })
         parse.cats.should.equal('meow')
       })
     })
@@ -1462,14 +1459,14 @@ describe('yargs-parser', function () {
             'camel-case-expansion': false
           }
         }), 'utf-8')
-        process.chdir('./test/fixtures/inner')
       })
 
       it('does not expand camel-case aliases', function () {
         var parsed = parser.detailed([], {
           alias: {
             'foo-bar': ['x']
-          }
+          },
+          cwd: './test/fixtures/inner'
         })
 
         expect(parsed.newAliases.fooBar).to.equal(undefined)
@@ -1477,7 +1474,9 @@ describe('yargs-parser', function () {
       })
 
       it('does not expand camel-case keys', function () {
-        var parsed = parser.detailed(['--foo-bar=apple'])
+        var parsed = parser.detailed(['--foo-bar=apple'], {
+          cwd: './test/fixtures/inner'
+        })
 
         expect(parsed.argv.fooBar).to.equal(undefined)
         expect(parsed.argv['foo-bar']).to.equal('apple')
@@ -1491,23 +1490,27 @@ describe('yargs-parser', function () {
             'dot-notation': false
           }
         }), 'utf-8')
-        process.chdir('./test/fixtures/inner')
       })
 
       it('does not expand dot notation defaults', function () {
         var parsed = parser([], {
           default: {
             'foo.bar': 'x'
-          }
+          },
+          cwd: './test/fixtures/inner'
         })
 
         expect(parsed['foo.bar']).to.equal('x')
       })
 
       it('does not expand dot notation arguments', function () {
-        var parsed = parser(['--foo.bar', 'banana'])
+        var parsed = parser(['--foo.bar', 'banana'], {
+          cwd: './test/fixtures/inner'
+        })
         expect(parsed['foo.bar']).to.equal('banana')
-        parsed = parser(['--foo.bar=banana'])
+        parsed = parser(['--foo.bar=banana'], {
+          cwd: './test/fixtures/inner'
+        })
         expect(parsed['foo.bar']).to.equal('banana')
       })
     })

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1483,5 +1483,33 @@ describe('yargs-parser', function () {
         expect(parsed.argv['foo-bar']).to.equal('apple')
       })
     })
+
+    describe('dot notation', function () {
+      beforeEach(function () {
+        fs.writeFileSync('./test/fixtures/package.json', JSON.stringify({
+          yargs: {
+            'dot-notation': false
+          }
+        }), 'utf-8')
+        process.chdir('./test/fixtures/inner')
+      })
+
+      it('does not expand dot notation defaults', function () {
+        var parsed = parser([], {
+          default: {
+            'foo.bar': 'x'
+          }
+        })
+
+        expect(parsed['foo.bar']).to.equal('x')
+      })
+
+      it('does not expand dot notation arguments', function () {
+        var parsed = parser(['--foo.bar', 'banana'])
+        expect(parsed['foo.bar']).to.equal('banana')
+        parsed = parser(['--foo.bar=banana'])
+        expect(parsed['foo.bar']).to.equal('banana')
+      })
+    })
   })
 })

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1514,5 +1514,59 @@ describe('yargs-parser', function () {
         expect(parsed['foo.bar']).to.equal('banana')
       })
     })
+
+    describe('parse numbers', function () {
+      beforeEach(function () {
+        fs.writeFileSync('./test/fixtures/package.json', JSON.stringify({
+          yargs: {
+            'parse-numbers': false
+          }
+        }), 'utf-8')
+      })
+
+      it('does not coerce defaults into numbers', function () {
+        var parsed = parser([], {
+          default: {
+            'foo': '5'
+          },
+          cwd: './test/fixtures/inner'
+        })
+
+        expect(parsed['foo']).to.equal('5')
+      })
+
+      it('does not coerce arguments into numbers', function () {
+        var parsed = parser(['--foo', '5'], {
+          cwd: './test/fixtures/inner'
+        })
+        expect(parsed['foo']).to.equal('5')
+      })
+
+      it('does not coerce positional arguments into numbers', function () {
+        var parsed = parser(['5'], {
+          cwd: './test/fixtures/inner'
+        })
+        expect(parsed._[0]).to.equal('5')
+      })
+    })
+
+    describe('boolean negation', function () {
+      beforeEach(function () {
+        fs.writeFileSync('./test/fixtures/package.json', JSON.stringify({
+          yargs: {
+            'boolean-negation': false
+          }
+        }), 'utf-8')
+      })
+
+      it('does not negate arguments prefixed with --no-', function () {
+        var parsed = parser(['--no-dice'], {
+          cwd: './test/fixtures/inner'
+        })
+
+        parsed['no-dice'].should.equal(true)
+        expect(parsed.dice).to.equal(undefined)
+      })
+    })
   })
 })


### PR DESCRIPTION
- [x] enable/disable boolean groups `-cats`.
- [x] enable/disable camel-case expansion.
- [x] enable/disable dot notation.
- [x] enable/disable number parsing.
- [x] enable/disable boolean negation.