### PR TITLE
switch to app-root-path module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var camelCase = require('camelcase')
-var findUp = require('find-up')
+var rootPath = require('app-root-path')
 var pkgConf = require('pkg-conf')
 var path = require('path')
 var tokenizeArgString = require('./lib/tokenize-arg-string')
@@ -12,7 +12,7 @@ function parse (args, opts) {
   args = tokenizeArgString(args)
   // aliases might have transitive relationships, normalize this.
   var aliases = combineAliases(opts.alias || {})
-  var configuration = loadConfiguration(opts.cwd || path.resolve(path.dirname(__filename), '../'))
+  var configuration = loadConfiguration(opts.cwd || rootPath.path)
   var defaults = opts.default || {}
   var envPrefix = opts.envPrefix
   var newAliases = {}
@@ -563,7 +563,7 @@ function loadConfiguration (cwd) {
       'parse-numbers': true,
       'boolean-negation': true
     },
-    cwd: findUp.sync('package.json', {cwd: cwd})
+    cwd: cwd
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "standard": "^5.4.1"
   },
   "dependencies": {
+    "app-root-path": "^1.0.0",
     "camelcase": "^2.0.1",
-    "find-up": "^1.1.0",
     "pkg-conf": "^1.1.1"
   }
 }


### PR DESCRIPTION
the [app-root-path](https://www.npmjs.com/package/app-root-path) module is well tested, and seems to bring us closer to the behavior I was looking for.