### PR TITLE
based on various discussions I've switched to require.main.filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Parses command line arguments returning a simple mapping of keys and values.
   * `opts.narg`: specify that a key requires `n` arguments: `{narg: {x: 2}}`.
   * `opts.normalize`: `path.normalize()` will be applied to values set to this key.
   * `opts.string`: keys should be treated as strings (even if they resemble a number `-x 33`).
+  * `opts.configuration`: provide configuration options to the yargs-parser (see: [configuration](#configuration)).
 
 **returns:**
 
@@ -85,19 +86,19 @@ yargs engine.
 * `newAliases`: any new aliases added via camel-case expansion.
 * `configuration`: the configuration loaded from the `yargs` stanza in package.json.
 
+<a name="configuration"></a>
 ### Configuration
 
 The yargs-parser applies several automated transformations on the keys provided
-in `args`. These features can be turned on and off by using the `yargs`
-configuration stanza in your package.json:
+in `args`. These features can be turned on and off using the `configuration` field
+of `opts`.
 
-```json
-{
-  "name": "my-awesome-module",
-  "yargs": {
-    "dot-notation": false
+```js
+var parsed = parser(['--no-dice'], {
+  configuration: {
+    'boolean-negation': false
   }
-}
+})
 ```
 
 ### short option groups

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var camelCase = require('camelcase')
-var findUp = require('find-up')
 var pkgConf = require('pkg-conf')
 var path = require('path')
 var tokenizeArgString = require('./lib/tokenize-arg-string')
@@ -12,7 +11,7 @@ function parse (args, opts) {
   args = tokenizeArgString(args)
   // aliases might have transitive relationships, normalize this.
   var aliases = combineAliases(opts.alias || {})
-  var configuration = loadConfiguration(opts.cwd || path.resolve(path.dirname(__filename), '../'))
+  var configuration = loadConfiguration(opts.cwd || path.dirname(require.main.filename))
   var defaults = opts.default || {}
   var envPrefix = opts.envPrefix
   var newAliases = {}
@@ -563,7 +562,7 @@ function loadConfiguration (cwd) {
       'parse-numbers': true,
       'boolean-negation': true
     },
-    cwd: findUp.sync('package.json', {cwd: cwd})
+    cwd: cwd
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var camelCase = require('camelcase')
 var pkgConf = require('pkg-conf')
+var requireMainFilename = require('require-main-filename')
 var path = require('path')
 var tokenizeArgString = require('./lib/tokenize-arg-string')
 var util = require('util')
@@ -11,7 +12,7 @@ function parse (args, opts) {
   args = tokenizeArgString(args)
   // aliases might have transitive relationships, normalize this.
   var aliases = combineAliases(opts.alias || {})
-  var configuration = loadConfiguration(opts.cwd || path.dirname(require.main.filename))
+  var configuration = loadConfiguration(opts.cwd || requireMainFilename())
   var defaults = opts.default || {}
   var envPrefix = opts.envPrefix
   var newAliases = {}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
+var assign = require('lodash.assign')
 var camelCase = require('camelcase')
-var pkgConf = require('pkg-conf')
-var requireMainFilename = require('require-main-filename')
 var path = require('path')
 var tokenizeArgString = require('./lib/tokenize-arg-string')
 var util = require('util')
@@ -12,7 +11,13 @@ function parse (args, opts) {
   args = tokenizeArgString(args)
   // aliases might have transitive relationships, normalize this.
   var aliases = combineAliases(opts.alias || {})
-  var configuration = loadConfiguration(opts.cwd || requireMainFilename())
+  var configuration = assign({}, {
+    'short-option-groups': true,
+    'camel-case-expansion': true,
+    'dot-notation': true,
+    'parse-numbers': true,
+    'boolean-negation': true
+  }, opts.configuration)
   var defaults = opts.default || {}
   var envPrefix = opts.envPrefix
   var newAliases = {}
@@ -552,19 +557,6 @@ function parse (args, opts) {
     newAliases: newAliases,
     configuration: configuration
   }
-}
-
-function loadConfiguration (cwd) {
-  return pkgConf.sync('yargs', {
-    defaults: {
-      'short-option-groups': true,
-      'camel-case-expansion': true,
-      'dot-notation': true,
-      'parse-numbers': true,
-      'boolean-negation': true
-    },
-    cwd: cwd
-  })
 }
 
 // if any aliases reference each other, we should

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "camelcase": "^2.0.1",
-    "find-up": "^1.1.0",
     "pkg-conf": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "camelcase": "^2.0.1",
-    "pkg-conf": "^1.1.1"
+    "pkg-conf": "^1.1.1",
+    "require-main-filename": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,16 +25,14 @@
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "devDependencies": {
-    "chai": "^3.4.1",
+    "chai": "^3.5.0",
     "coveralls": "^2.11.6",
-    "mocha": "^2.3.4",
-    "nyc": "^5.3.0",
-    "rimraf": "^2.5.1",
-    "standard": "^5.4.1"
+    "mocha": "^2.4.5",
+    "nyc": "^5.6.0",
+    "standard": "^6.0.1"
   },
   "dependencies": {
-    "camelcase": "^2.0.1",
-    "pkg-conf": "^1.1.1",
-    "require-main-filename": "^1.0.0"
+    "camelcase": "^2.1.0",
+    "lodash.assign": "^4.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coveralls": "^2.11.6",
     "mocha": "^2.4.5",
     "nyc": "^5.6.0",
-    "standard": "^6.0.1"
+    "standard": "^5.4.1"
   },
   "dependencies": {
     "camelcase": "^2.1.0",

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1,4 +1,4 @@
-/* global beforeEach, describe, it, afterEach */
+/* global beforeEach, describe, it */
 
 require('chai').should()
 
@@ -6,7 +6,6 @@ var expect = require('chai').expect
 var fs = require('fs')
 var parser = require('../')
 var path = require('path')
-var rimraf = require('rimraf')
 
 describe('yargs-parser', function () {
   it('should parse a "short boolean"', function () {
@@ -1412,61 +1411,32 @@ describe('yargs-parser', function () {
   })
 
   describe('configuration', function () {
-    beforeEach(function () {
-      rimraf.sync('./test/fixtures/package.json')
-    })
-
-    afterEach(function () {
-      rimraf.sync('./test/fixtures/package.json')
-    })
-
-    it('reads configuration from parent package.json', function () {
-      fs.writeFileSync('./test/fixtures/package.json', JSON.stringify({
-        yargs: {
-          'short-option-groups': false
-        }
-      }), 'utf-8')
-
-      var result = parser.detailed([], {
-        cwd: './test/fixtures/inner'
-      })
-      result.configuration['short-option-groups'].should.equal(false)
-    })
-
     describe('short option groups', function () {
       it('allows short-option-groups to be disabled', function () {
-        fs.writeFileSync('./test/fixtures/package.json', JSON.stringify({
-          yargs: {
+        var parse = parser(['-cats=meow'], {
+          configuration: {
             'short-option-groups': false
           }
-        }), 'utf-8')
-
-        var parse = parser(['-cats=meow'], {
-          cwd: './test/fixtures/inner'
         })
         parse.cats.should.equal('meow')
         parse = parser(['-cats', 'meow'], {
-          cwd: './test/fixtures/inner'
+          configuration: {
+            'short-option-groups': false
+          }
         })
         parse.cats.should.equal('meow')
       })
     })
 
     describe('camel-case expansion', function () {
-      beforeEach(function () {
-        fs.writeFileSync('./test/fixtures/package.json', JSON.stringify({
-          yargs: {
-            'camel-case-expansion': false
-          }
-        }), 'utf-8')
-      })
-
       it('does not expand camel-case aliases', function () {
         var parsed = parser.detailed([], {
           alias: {
             'foo-bar': ['x']
           },
-          cwd: './test/fixtures/inner'
+          configuration: {
+            'camel-case-expansion': false
+          }
         })
 
         expect(parsed.newAliases.fooBar).to.equal(undefined)
@@ -1475,7 +1445,9 @@ describe('yargs-parser', function () {
 
       it('does not expand camel-case keys', function () {
         var parsed = parser.detailed(['--foo-bar=apple'], {
-          cwd: './test/fixtures/inner'
+          configuration: {
+            'camel-case-expansion': false
+          }
         })
 
         expect(parsed.argv.fooBar).to.equal(undefined)
@@ -1484,20 +1456,14 @@ describe('yargs-parser', function () {
     })
 
     describe('dot notation', function () {
-      beforeEach(function () {
-        fs.writeFileSync('./test/fixtures/package.json', JSON.stringify({
-          yargs: {
-            'dot-notation': false
-          }
-        }), 'utf-8')
-      })
-
       it('does not expand dot notation defaults', function () {
         var parsed = parser([], {
           default: {
             'foo.bar': 'x'
           },
-          cwd: './test/fixtures/inner'
+          configuration: {
+            'dot-notation': false
+          }
         })
 
         expect(parsed['foo.bar']).to.equal('x')
@@ -1505,31 +1471,29 @@ describe('yargs-parser', function () {
 
       it('does not expand dot notation arguments', function () {
         var parsed = parser(['--foo.bar', 'banana'], {
-          cwd: './test/fixtures/inner'
+          configuration: {
+            'dot-notation': false
+          }
         })
         expect(parsed['foo.bar']).to.equal('banana')
         parsed = parser(['--foo.bar=banana'], {
-          cwd: './test/fixtures/inner'
+          configuration: {
+            'dot-notation': false
+          }
         })
         expect(parsed['foo.bar']).to.equal('banana')
       })
     })
 
     describe('parse numbers', function () {
-      beforeEach(function () {
-        fs.writeFileSync('./test/fixtures/package.json', JSON.stringify({
-          yargs: {
-            'parse-numbers': false
-          }
-        }), 'utf-8')
-      })
-
       it('does not coerce defaults into numbers', function () {
         var parsed = parser([], {
           default: {
             'foo': '5'
           },
-          cwd: './test/fixtures/inner'
+          configuration: {
+            'parse-numbers': false
+          }
         })
 
         expect(parsed['foo']).to.equal('5')
@@ -1537,31 +1501,29 @@ describe('yargs-parser', function () {
 
       it('does not coerce arguments into numbers', function () {
         var parsed = parser(['--foo', '5'], {
-          cwd: './test/fixtures/inner'
+          configuration: {
+            'parse-numbers': false
+          }
         })
         expect(parsed['foo']).to.equal('5')
       })
 
       it('does not coerce positional arguments into numbers', function () {
         var parsed = parser(['5'], {
-          cwd: './test/fixtures/inner'
+          configuration: {
+            'parse-numbers': false
+          }
         })
         expect(parsed._[0]).to.equal('5')
       })
     })
 
     describe('boolean negation', function () {
-      beforeEach(function () {
-        fs.writeFileSync('./test/fixtures/package.json', JSON.stringify({
-          yargs: {
-            'boolean-negation': false
-          }
-        }), 'utf-8')
-      })
-
       it('does not negate arguments prefixed with --no-', function () {
         var parsed = parser(['--no-dice'], {
-          cwd: './test/fixtures/inner'
+          configuration: {
+            'boolean-negation': false
+          }
         })
 
         parsed['no-dice'].should.equal(true)


### PR DESCRIPTION
Based on discussions with @sindresorhus, @isaacs, and @iarna, I've switched to using:

`require.main.filename`

I've thoroughly tested this approach with the following testing module:

https://www.npmjs.com/package/yargs-testing-module

And the following branch of yargs, which has integration tests for symlinks:

https://github.com/bcoe/yargs/pull/356

Using the two approaches outlined above, I've tested the following on `npm 2.x` and `npm 3.x`:

* global installs.
* running locally.
* symlinks.
* and nested dependencies.

Sorry for keeping this conversation going so long, I really want to be careful to get this right (`yargs@4.x` needs to be an improvement not a step backwards).

Reviewers: @sindresorhus, @jameswomack, @nexdrew 