### PR TITLE
Add new type 'number'

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Parses command line arguments returning a simple mapping of keys and values.
   * `opts.narg`: specify that a key requires `n` arguments: `{narg: {x: 2}}`.
   * `opts.normalize`: `path.normalize()` will be applied to values set to this key.
   * `opts.string`: keys should be treated as strings (even if they resemble a number `-x 33`).
+  * `opts.number`: keys should be treated as numbers.
 
 **returns:**
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function parse (args, opts) {
     arrays: {},
     bools: {},
     strings: {},
+    numbers: {},
     counts: {},
     normalize: {},
     configs: {},
@@ -43,6 +44,10 @@ function parse (args, opts) {
 
   ;[].concat(opts.string).filter(Boolean).forEach(function (key) {
     flags.strings[key] = true
+  })
+
+  ;[].concat(opts.number).filter(Boolean).forEach(function (key) {
+    flags.numbers[key] = true
   })
 
   ;[].concat(opts.count).filter(Boolean).forEach(function (key) {
@@ -522,6 +527,7 @@ function parse (args, opts) {
     var def = {
       boolean: true,
       string: '',
+      number: undefined,
       array: []
     }
 
@@ -533,6 +539,7 @@ function parse (args, opts) {
     var type = 'boolean'
 
     if (flags.strings && flags.strings[key]) type = 'string'
+    else if (flags.numbers && flags.numbers[key]) type = 'number'
     else if (flags.arrays && flags.arrays[key]) type = 'array'
 
     return type

--- a/index.js
+++ b/index.js
@@ -546,6 +546,7 @@ function parse (args, opts) {
   }
 
   function isNumber (x) {
+    if (flags.numbers && flags.numbers[x] && Number(x) === NaN) return true
     if (!configuration['parse-numbers']) return false
     if (typeof x === 'number') return true
     if (/^0x[0-9a-f]+$/i.test(x)) return true

--- a/index.js
+++ b/index.js
@@ -546,7 +546,7 @@ function parse (args, opts) {
   }
 
   function isNumber (x) {
-    if (flags.numbers && flags.numbers[x] && Number(x) === NaN) return true
+    if (flags.numbers && flags.numbers[x] && !isNaN(x)) return true
     if (!configuration['parse-numbers']) return false
     if (typeof x === 'number') return true
     if (/^0x[0-9a-f]+$/i.test(x)) return true

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -176,6 +176,20 @@ describe('yargs-parser', function () {
     x.should.be.a('string').and.equal('56')
   })
 
+  it('should default numbers to undefined', function () {
+    var n = parser([ '-n' ], {
+      number: ['n']
+    }).n
+    expect(n).to.equal(undefined)
+  })
+
+  it('should default number to NaN if value is not a valid number', function () {
+    var n = parser([ '-n', 'string' ], {
+      number: ['n']
+    }).n
+    expect(n).to.equal(NaN)
+  })
+
   // Fixes: https://github.com/bcoe/yargs/issues/68
   it('should parse flag arguments with no right-hand-value as strings, if defined as strings', function () {
     var s = parser([ '-s' ], {


### PR DESCRIPTION
This adds a new type `number`.

A `number`-type option has the following special behaviour:
- If the flag itself is not provided, its value will default to `undefined`, _unless_ defined otherwise via `.default()`
- If no number is provided as a value, its value will default to `NaN` (that means, if `Number()` isn't capable of coercing the value to a `number` primitive)

_Note_: Where should I implement the logic for checking if the given value is a number? I thought of the following code:
```javascript
if (typeof x === 'number') {
  return x
} else {
  return Number(x) // Will return NaN if x is not coercible to a number
}
```
I am aware of `isNumber()`, however, it only returns true if the option `parse-numbers` equals `false`, which is obviously not related to the `number`-type. What do folks think?