### PR TITLE
Fix behaviour for arrays when passed with no value and as the first option

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,9 +289,10 @@ function parse (args, opts) {
   // following it... YUM!
   // e.g., --foo apple banana cat becomes ["apple", "banana", "cat"]
   function eatArray (i, key, args) {
+    var start = i + 1
     for (var ii = i + 1; ii < args.length; ii++) {
       if (/^-/.test(args[ii])) {
-        if (args[ii - 1].replace('-', '') === key) {
+        if (ii === start) {
           setArg(key, defaultForType('array'))
         }
         break

--- a/index.js
+++ b/index.js
@@ -290,7 +290,12 @@ function parse (args, opts) {
   // e.g., --foo apple banana cat becomes ["apple", "banana", "cat"]
   function eatArray (i, key, args) {
     for (var ii = i + 1; ii < args.length; ii++) {
-      if (/^-/.test(args[ii])) break
+      if (/^-/.test(args[ii])) {
+        if (args[ii - 1].replace('-', '') === key) {
+          setArg(key, defaultForType('array'))
+        }
+        break
+      }
       i = ii
       setArg(key, args[ii])
     }

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1110,6 +1110,13 @@ describe('yargs-parser', function () {
       parse.should.have.property('_').with.length(0)
     })
 
+    it('should default an array to an empty array if passed as first option followed by another', function () {
+      var result = parser(['-a', '-b'], {
+        array: 'a'
+      })
+      result.should.have.property('a').and.deep.equal([])
+    })
+
     it('should default argument to empty array if no value given', function () {
       var result = parser(['-b'], {
         array: 'b'

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1117,6 +1117,13 @@ describe('yargs-parser', function () {
       result.should.have.property('a').and.deep.equal([])
     })
 
+    it('should not attempt to default array if an element has already been populated', function () {
+      var result = parser(['-a', 'foo', 'bar', '-b'], {
+        array: 'a'
+      })
+      result.should.have.property('a').and.deep.equal(['foo', 'bar'])
+    })
+
     it('should default argument to empty array if no value given', function () {
       var result = parser(['-b'], {
         array: 'b'

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1128,7 +1128,7 @@ describe('yargs-parser', function () {
       var result = parser(['-b'], {
         array: 'b'
       })
-      Array.isArray(result.b).should.equal(true)
+      result.should.have.property('b').and.deep.equal([])
     })
 
     it('should place value of argument in array, when one argument provided', function () {


### PR DESCRIPTION
This fixes [yargs/#383](https://github.com/bcoe/yargs/issues/383#issuecomment-185270189).

If passed as the first option, without grouping and value, an array option would not get defined as `eatArray()` does simply abort if it doesn't see any value passed. This fix makes `eatArray()` assign the array option the default value if no value is provided.

There might be a more elegant solution, though...