### PR TITLE
Copy args before parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -626,7 +626,7 @@ function increment (orig) {
 }
 
 function Parser (args, opts) {
-  var result = parse(args, opts)
+  var result = parse(args.slice(), opts)
 
   return result.argv
 }
@@ -634,7 +634,7 @@ function Parser (args, opts) {
 // parse arguments and return detailed
 // meta information, aliases, etc.
 Parser.detailed = function (args, opts) {
-  return parse(args, opts)
+  return parse(args.slice(), opts)
 }
 
 module.exports = Parser

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1270,6 +1270,26 @@ describe('yargs-parser', function () {
       result._[1].should.equal('cat')
     })
 
+    it('should not modify the input args if an = was used', function () {
+      var expected = ['-f=apple', 'bar', 'blerg', '--bar=monkey', 'washing', 'cat']
+      var args = expected.slice()
+      parser(args, {
+        narg: {
+          f: 2,
+          bar: 2
+        }
+      })
+      args.should.deep.equal(expected)
+
+      parser.detailed(args, {
+        narg: {
+          f: 2,
+          bar: 2
+        }
+      })
+      args.should.deep.equal(expected)
+    })
+
     it('allows multiple nargs to be set at the same time', function () {
       var result = parser([ '--foo', 'apple', 'bar', '--bar', 'banana', '-f' ], {
         narg: {


### PR DESCRIPTION
When a flag is encountered with nargs set, and = is used, the input args array is modified. This breaks recursive command parsing in yargs itself.

Copy the args before parsing and add a test which shows the problem.

Fixes https://github.com/yargs/yargs/issues/396