### PR TITLE
Join 'keys' in hasKey() when 'dot-notation' is turned off

### DIFF
--- a/index.js
+++ b/index.js
@@ -450,6 +450,9 @@ function parse (args, opts) {
 
   function hasKey (obj, keys) {
     var o = obj
+
+    if (!configuration['dot-notation']) keys = [keys.join('.')]
+
     keys.slice(0, -1).forEach(function (key) {
       o = (o[key] || {})
     })

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1531,6 +1531,35 @@ describe('yargs-parser', function () {
         })
         expect(parsed['foo.bar']).to.equal('banana')
       })
+
+      it('should use value from cli, if cli overrides dot notation default', function () {
+        var parsed = parser(['--foo.bar', 'abc'], {
+          default: {
+            'foo.bar': 'default'
+          },
+          configuration: {
+            'dot-notation': false
+          }
+        })
+
+        expect(parsed['foo.bar']).to.equal('abc')
+      })
+
+      it('should also override dot notation alias', function () {
+        var parsed = parser(['--foo.bar', 'abc'], {
+          alias: {
+            'foo.bar': ['alias.bar']
+          },
+          default: {
+            'foo.bar': 'default'
+          },
+          configuration: {
+            'dot-notation': false
+          }
+        })
+
+        expect(parsed['alias.bar']).to.equal('abc')
+      })
     })
 
     describe('parse numbers', function () {


### PR DESCRIPTION
I added a check for `configuration['dot-notation']` in `hasKey`, just like `setKey` already has. This way, if dot-notation is turned off, the keys will be joined. Therefore `hasKey` will be able to correctly tell if the key is in `obj`, without trying to check nested objects.

Without this fix, some errors occur when calling `applyDefaultsAndAliases` (which is the only method that calls `hasKey`) while dot-notation is disabled. For example:

- Values from the cli would fail to override defaults, if the defaults have dots.
- Values from the cli also fail to override aliases, if the aliases have dots.