### PR TITLE
Fix args.splice() when handling the case '--foo=xxx' with nargs or arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,11 +121,11 @@ function parse (args, opts) {
 
       // nargs format = '--f=monkey washing cat'
       if (checkAllAliases(m[1], flags.nargs)) {
-        args.splice(i + 1, m[1], m[2])
+        args.splice(i + 1, 0, m[2])
         i = eatNargs(i, m[1], args)
       // arrays format = '--f=a b c'
       } else if (checkAllAliases(m[1], flags.arrays) && args.length > i + 1) {
-        args.splice(i + 1, m[1], m[2])
+        args.splice(i + 1, 0, m[2])
         i = eatArray(i, m[1], args)
       } else {
         setArg(m[1], m[2])

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1217,6 +1217,17 @@ describe('yargs-parser', function () {
       result.bar.should.include('cat')
       result.bar.should.include('dog')
     })
+
+    // see: https://github.com/yargs/yargs-parser/pull/13
+    it('should support array for --foo= format when the key is a number', function () {
+      var result = parser(['--1=a', 'b'], {
+        array: ['1']
+      })
+
+      Array.isArray(result['1']).should.equal(true)
+      result['1'][0].should.equal('a')
+      result['1'][1].should.equal('b')
+    })
   })
 
   describe('nargs', function () {
@@ -1317,6 +1328,19 @@ describe('yargs-parser', function () {
       result.foo[1].should.equal('bar')
       result.bar.should.equal('banana')
       result.f.should.equal(true)
+    })
+
+    // see: https://github.com/yargs/yargs-parser/pull/13
+    it('should support nargs for --foo= format when the key is a number', function () {
+      var result = parser(['--1=a', 'b'], {
+        narg: {
+          1: 2
+        }
+      })
+
+      Array.isArray(result['1']).should.equal(true)
+      result['1'][0].should.equal('a')
+      result['1'][1].should.equal('b')
     })
   })
 


### PR DESCRIPTION
When handling the `--f=a b c` case, if the key of `--f=a` is in 'nargs' or 'arrays', then the value 'a' is added as the next item in 'args'. 

There's an issue with the call used for that: `args.splice(i + 1, m[1], m[2])`, where `m[1]` is the key and `m[2]` is the value. There should be a zero in place of `m[1]`, because the signature of splice is `array.splice(start, deleteCount[, item1[, item2[, ...]]])`, and we don't actually try to delete anything from 'args'.

An edge case error occurs if the key is actually a number. If so, that number of items will be deleted from args. (For example: Calling with `--1=a b` will result in `1 = ["a", null]`).

Note than the args.splice call is already used correctly when handling the `-f=a b c` case.