### PR TITLE
Allow nested options in config files

### DIFF
--- a/test/fixtures/nested_config.json
+++ b/test/fixtures/nested_config.json
@@ -1,0 +1,8 @@
+{
+  "a": "a",
+  "nested": {
+    "foo": "baz",
+    "bar": "bar"
+  },
+  "b": "b"
+}

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -473,6 +473,37 @@ describe('yargs-parser', function () {
       expect(argv.error).to.equal(null)
     })
 
+    it('should load nested options from config file', function () {
+      var jsonPath = path.resolve(__dirname, './fixtures/nested_config.json')
+      var argv = parser(['--settings', jsonPath, '--nested.foo', 'bar'], {
+        config: ['settings']
+      })
+
+      argv.should.have.property('a', 'a')
+      argv.should.have.property('b', 'b')
+      argv.should.have.property('nested').and.deep.equal({
+        foo: 'bar',
+        bar: 'bar'
+      })
+    })
+
+    it('should use nested value from config file, if argv value is using default value', function () {
+      var jsonPath = path.resolve(__dirname, './fixtures/nested_config.json')
+      var argv = parser(['--settings', jsonPath], {
+        config: ['settings'],
+        default: {
+          'nested.foo': 'banana'
+        }
+      })
+
+      argv.should.have.property('a', 'a')
+      argv.should.have.property('b', 'b')
+      argv.should.have.property('nested').and.deep.equal({
+        foo: 'baz',
+        bar: 'bar'
+      })
+    })
+
     it('allows a custom parsing function to be provided', function () {
       var jsPath = path.resolve(__dirname, './fixtures/config.txt')
       var argv = parser([ '--settings', jsPath, '--foo', 'bar' ], {


### PR DESCRIPTION
It solves yargs/yargs#292.

`setConfig()` now checks the config object recursively, and calls `setArg()` for every nested key if that key isn't in argv or has the default value.
