### PR TITLE
Fix issue with dot-expansion disabled and an alias of the first element of a dot-notation key

### DIFF
--- a/index.js
+++ b/index.js
@@ -338,28 +338,27 @@ function parse (args, opts) {
     var splitKey = key.split('.')
     setKey(argv, splitKey, value)
 
-    // alias references an inner-value within
-    // a dot-notation object. see #279.
-    if (~key.indexOf('.') && flags.aliases[key]) {
+    // handle populating aliases of the full key
+    if (flags.aliases[key]) {
       flags.aliases[key].forEach(function (x) {
         x = x.split('.')
         setKey(argv, x, value)
       })
     }
 
-    ;(flags.aliases[splitKey[0]] || []).forEach(function (x) {
-      x = x.split('.')
+    // handle populating aliases of the first element of the dot-notation key
+    if (splitKey.length > 1 && configuration['dot-notation']) {
+      ;(flags.aliases[splitKey[0]] || []).forEach(function (x) {
+        x = x.split('.')
 
-      // handle populating dot notation for both
-      // the key and its aliases.
-      if (splitKey.length > 1) {
+        // expand alias with nested objects in key
         var a = [].concat(splitKey)
         a.shift() // nuke the old key.
         x = x.concat(a)
-      }
 
-      setKey(argv, x, value)
-    })
+        setKey(argv, x, value)
+      })
+    }
 
     var keys = [key].concat(flags.aliases[key] || [])
     for (var i = 0, l = keys.length; i < l; i++) {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1615,6 +1615,19 @@ describe('yargs-parser', function () {
 
         expect(parsed['alias.bar']).to.equal('abc')
       })
+
+      it('does not expand alias of first element of dot notation arguments', function () {
+        var parsed = parser(['--foo.bar', 'banana'], {
+          alias: {
+            'foo': ['f']
+          },
+          configuration: {
+            'dot-notation': false
+          }
+        })
+        expect(parsed['foo.bar']).to.equal('banana')
+        expect(parsed).not.to.include.keys('f.bar')
+      })
     })
 
     describe('parse numbers', function () {


### PR DESCRIPTION
Calling this:
```javascript
var parsed = yargs(process.argv.slice(2), {
  alias: {'foo': 'f'},
  configuration: {'dot-notation': false}
})
```
With `--foo.bar "value"` results in the value being set to the key `'f.bar'`.

This fix removes the expansion of an alias of the first element of a dot-notation key, when dot-notation is disabled.

I simplified a bit the two loops that set aliases in `SetArg()`, because this new condition was making them a bit hard to follow. I moved one of the cases (calling `setKey()` for the full key if it doesn't have dot notation) from the second loop to the first loop. Here's how it looks now:
- The first loop calls `setKey()` for aliases of the full key, if the key key has dots or not.
- The second loop expands aliases of the first element in a dot-notation key, but only if dot-notation is enabled.
