### PR TITLE
Fix Boolean flag when next value contains the strings 'true' or 'false'

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,7 +245,7 @@ function parse (args, opts) {
             !checkAllAliases(key, flags.counts)) {
             setArg(key, next)
             i++
-          } else if (/true|false/.test(next)) {
+          } else if (/^(true|false)$/.test(next)) {
             setArg(key, next)
             i++
           } else {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -153,6 +153,15 @@ describe('yargs-parser', function () {
     parse.should.have.property('_').and.deep.equal(['moo'])
   })
 
+  it('should not set boolean options values if the next value only contains the words "true" or "false"', function () {
+    var parse = parser(['--verbose', 'aaatrueaaa', 'moo', '-t', 'aaafalseaaa'], {
+      boolean: ['t', 'verbose']
+    })
+    parse.should.have.property('verbose', true).and.be.a('boolean')
+    parse.should.have.property('t', true).and.be.a('boolean')
+    parse.should.have.property('_').and.deep.equal(['aaatrueaaa', 'moo', 'aaafalseaaa'])
+  })
+
   it('should allow defining options as boolean in groups', function () {
     var parse = parser([ '-x', '-z', 'one', 'two', 'three' ], {
       boolean: ['x', 'y', 'z']


### PR DESCRIPTION
When calling `test.js -b aaafalseaaa`, and `b` is a boolean, the value of `'b'` is set to `false` and `'aaafalseaaa'` doesn't appear in `'_'`.

I fixed this by updating the regex to look like the one in the `--foo true` case, where it works fine.
