### PR TITLE
Handle calling short option with an empty string as the next value.

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,12 +240,12 @@ function parse (args, opts) {
         } else {
           next = args[i + 1]
 
-          if (next && !/^(-|--)[^-]/.test(next) &&
+          if (next !== undefined && !/^(-|--)[^-]/.test(next) &&
             !checkAllAliases(key, flags.bools) &&
             !checkAllAliases(key, flags.counts)) {
             setArg(key, next)
             i++
-          } else if (next && /true|false/.test(next)) {
+          } else if (/true|false/.test(next)) {
             setArg(key, next)
             i++
           } else {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -40,6 +40,12 @@ describe('yargs-parser', function () {
     parse.should.have.property('_').with.length(0)
   })
 
+  it('should set the value of a single long option to the next supplied value, even if the value is empty', function () {
+    var parse = parser(['--pow', ''])
+    parse.should.have.property('pow', '')
+    parse.should.have.property('_').with.length(0)
+  })
+
   it('should set the value of a single long option if an = was used', function () {
     var parse = parser(['--pow=xixxle'])
     parse.should.have.property('pow', 'xixxle')
@@ -119,6 +125,12 @@ describe('yargs-parser', function () {
     argv.should.have.property('hex', 0xdeadbeef).and.be.a('number')
     argv.should.have.property('_').and.deep.equal([789])
     argv._[0].should.be.a('number')
+  })
+
+  it('should set the value of a single short option to the next supplied value, even if the value is empty', function () {
+    var parse = parser(['-p', ''])
+    parse.should.have.property('p', '')
+    parse.should.have.property('_').with.length(0)
   })
 
   it('should not set the next value as the value of a short option if that option is explicitly defined as a boolean', function () {


### PR DESCRIPTION
Calling with a short option followed by a falsy value (like the empty string `""`) results in the value not applied to the flag.

For example, calling `-f ""` results in `{'_':[""], 'f':true}` instead of `{'_':[], 'f':""}`

I fixed this by updating the check to look like the one in the `--foo ""` case, where it works fine.