### PR TITLE
Fix issue with numeric character in group of options

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,8 +212,9 @@ function parse (args, opts) {
           continue
         }
 
+        // current letter is an alphabetic character and next value is a number
         if (/[A-Za-z]/.test(letters[j]) &&
-          /-?\d+(\.\d*)?(e-?\d+)?$/.test(next)) {
+          /^-?\d+(\.\d*)?(e-?\d+)?$/.test(next)) {
           setArg(letters[j], next)
           broken = true
           break

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -762,6 +762,29 @@ describe('yargs-parser', function () {
       argv.should.have.property('n', 123)
     })
 
+    it('should set n to the numeric value 123, with n at the end of a group', function () {
+      var argv = parser([ '-ab5n123' ])
+      argv.should.have.property('a', true)
+      argv.should.have.property('b', true)
+      argv.should.have.property('5', true)
+      argv.should.have.property('n', 123)
+      argv.should.have.property('_').with.length(0)
+    })
+
+    it('should set n to the numeric value 123, with = as separator', function () {
+      var argv = parser([ '-n=123' ])
+      argv.should.have.property('n', 123)
+    })
+
+    it('should set n to the numeric value 123, with n at the end of a group and = as separator', function () {
+      var argv = parser([ '-ab5n=123' ])
+      argv.should.have.property('a', true)
+      argv.should.have.property('b', true)
+      argv.should.have.property('5', true)
+      argv.should.have.property('n', 123)
+      argv.should.have.property('_').with.length(0)
+    })
+
     it('should set option "1" to true, option "2" to true, and option "3" to numeric value 456', function () {
       var argv = parser([ '-123', '456' ])
       argv.should.have.property('1', true)


### PR DESCRIPTION
When checking a group of options, if there is any number in the characters following the key being currently evaluated, then everything after the current key will be set as its value. This happens because the regex that checks for numbers is missing a `^` at the beginning, so strings like `'abc123'` are considered numbers.

An issue caused by this is that, for example, calling `-abc=123` results in `{"_": [], "a": "bc=123"}` instead of `{"_": [], "a": true, "b": true, "c": 123}`