### PR TITLE
Fix Boolean options with non boolean defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -494,7 +494,7 @@ function parse (args, opts) {
       o[key] = increment(o[key])
     } else if (o[key] === undefined && checkAllAliases(key, flags.arrays)) {
       o[key] = Array.isArray(value) ? value : [value]
-    } else if (o[key] === undefined || typeof o[key] === 'boolean') {
+    } else if (o[key] === undefined || checkAllAliases(key, flags.bools)) {
       o[key] = value
     } else if (Array.isArray(o[key])) {
       o[key].push(value)

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -866,7 +866,7 @@ describe('yargs-parser', function () {
     })
 
     describe('for boolean options', function () {
-      [true, false, undefined].forEach(function (def) {
+      [true, false, undefined, null].forEach(function (def) {
         describe('with explicit ' + def + ' default', function () {
           var opts = {
             default: {


### PR DESCRIPTION
Inspired by this issue in minimist: https://github.com/substack/minimist/issues/44

It you have a boolean flag with a default to something that isn't a boolean. For example:
```javascript
var parsed = yargs(process.argv.slice(2), {
  boolean: ['foo'],
  default: {foo: null}
})
```
Then calling with `--foo` will result in `{"_": [], "foo": [null, true]}`.

I updated `setKey()` to avoid creating an array if the key in `argv` is in `flags.bools`. Previously, it only checked if the current value for the key in `argv` was a Boolean, but that didn't consider the case when a non-Boolean is set by default.

Note that setting a non-Boolean default for a Boolean key can be useful, as in the referenced issue, to find out if a key was explicitly set by the user in the CLI.