### PR TITLE
Exclude tests from publication

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.nyc_output
-node_modules
-.DS_Store
-yargs-logo.png
-./test/fixtures/package.json

--- a/package.json
+++ b/package.json
@@ -34,5 +34,9 @@
   "dependencies": {
     "camelcase": "^2.1.1",
     "lodash.assign": "^4.0.6"
-  }
+  },
+  "files": [
+    "lib",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
This came up recently in https://github.com/yargs/yargs/issues/468#issuecomment-206442013.

Would be nice to trim the package size a bit by excluding tests, and I prefer whitelisting files in `package.json` over blacklisting files in `.npmignore`.

Here is the result of `npm pack` before and after this change:

```
# BEFORE
x package/package.json
x package/.npmignore
x package/README.md
x package/example.js
x package/index.js
x package/appveyor.yml
x package/.travis.yml
x package/lib/tokenize-arg-string.js
x package/test/tokenize-arg-string.js
x package/test/yargs-parser.js
x package/test/fixtures/settings.js
x package/test/fixtures/config.json
x package/test/fixtures/config.txt
x package/test/fixtures/nested_config.json
x package/LICENSE.txt

# AFTER
x package/package.json
x package/README.md
x package/index.js
x package/lib/tokenize-arg-string.js
x package/LICENSE.txt
```