### PR TITLE
feat(configuration): Allow to pass configuration objects to yargs-parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function parse (args, opts) {
     'boolean-negation': true
   }, opts.configuration)
   var defaults = opts.default || {}
+  var configObjects = opts.configObjects || []
   var envPrefix = opts.envPrefix
   var newAliases = {}
   // allow a i18n handler to be passed in, default to a fake one (util.format).
@@ -263,10 +264,12 @@ function parse (args, opts) {
   // order of precedence:
   // 1. command line arg
   // 2. value from config file
-  // 3. value from env var
-  // 4. configured default value
+  // 3. value from config objects
+  // 4. value from env var
+  // 5. configured default value
   applyEnvVars(argv, true) // special case: check env vars that point to config file
   setConfig(argv)
+  setConfigObjects()
   applyEnvVars(argv, false)
   applyDefaultsAndAliases(argv, flags.aliases, defaults)
 
@@ -433,6 +436,14 @@ function parse (args, opts) {
           setArg(fullKey, value)
         }
       }
+    })
+  }
+
+  // set all config objects passed in opts
+  function setConfigObjects () {
+    if (typeof configObjects === 'undefined') return
+    configObjects.forEach(function (configObject) {
+      setConfigObject(configObject)
     })
   }
 

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -571,6 +571,102 @@ describe('yargs-parser', function () {
     })
   })
 
+  describe('config objects', function () {
+    it('should load options from config object', function () {
+      var argv = parser([ '--foo', 'bar' ], {
+        configObjects: [{
+          apple: 'apple',
+          banana: 42,
+          foo: 'baz'
+        }]
+      })
+
+      argv.should.have.property('apple', 'apple')
+      argv.should.have.property('banana', 42)
+      argv.should.have.property('foo', 'bar')
+    })
+
+    it('should use value from config object, if argv value is using default value', function () {
+      var argv = parser([], {
+        configObjects: [{
+          apple: 'apple',
+          banana: 42,
+          foo: 'baz'
+        }],
+        default: {
+          foo: 'banana'
+        }
+      })
+
+      argv.should.have.property('apple', 'apple')
+      argv.should.have.property('banana', 42)
+      argv.should.have.property('foo', 'baz')
+    })
+
+    it('should use value from config object to all aliases', function () {
+      var argv = parser([], {
+        configObjects: [{
+          apple: 'apple',
+          banana: 42,
+          foo: 'baz'
+        }],
+        alias: {
+          a: ['apple'],
+          banana: ['b']
+        }
+      })
+
+      argv.should.have.property('apple', 'apple')
+      argv.should.have.property('a', 'apple')
+      argv.should.have.property('banana', 42)
+      argv.should.have.property('b', 42)
+      argv.should.have.property('foo', 'baz')
+    })
+
+    it('should load nested options from config object', function () {
+      var argv = parser(['--nested.foo', 'bar'], {
+        configObjects: [{
+          a: 'a',
+          nested: {
+            foo: 'baz',
+            bar: 'bar'
+          },
+          b: 'b'
+        }]
+      })
+
+      argv.should.have.property('a', 'a')
+      argv.should.have.property('b', 'b')
+      argv.should.have.property('nested').and.deep.equal({
+        foo: 'bar',
+        bar: 'bar'
+      })
+    })
+
+    it('should use nested value from config object, if argv value is using default value', function () {
+      var argv = parser([], {
+        configObjects: [{
+          a: 'a',
+          nested: {
+            foo: 'baz',
+            bar: 'bar'
+          },
+          b: 'b'
+        }],
+        default: {
+          'nested.foo': 'banana'
+        }
+      })
+
+      argv.should.have.property('a', 'a')
+      argv.should.have.property('b', 'b')
+      argv.should.have.property('nested').and.deep.equal({
+        foo: 'baz',
+        bar: 'bar'
+      })
+    })
+  })
+
   describe('dot notation', function () {
     it('should allow object graph traversal via dot notation', function () {
       var argv = parser([


### PR DESCRIPTION
This was brought to by https://github.com/yargs/yargs/issues/435, about aliases not being set correctly to values set by `pkgConf`. (It also solves https://github.com/yargs/yargs/issues/423).

For aliases to be handled correctly, even considering transitive relationships, `pkgConf` values should be handled in yargs-parser, where most of the logic of aliases is. So, the solution here is to pass the object from the key in `package.json` to yargs-parser.

This is the first part of a solution that would later need yargs to pass the object to yargs-parser.

Here are some design considerations I made:
- I thought the best is to add a generic key to `opts` in yargs-parser, called `configObjects` that takes arbitrary objects and adds them to `argv`. So as to avoid coupling it with `pkgConf`. That way it makes sense to people who use yargs-parser by itself.
- Also, I thought it's fine for the `configObjects` values to have almost the same priority that values set by a config file, after all, they are another way of configuration. An issue with that is that values from `pkgConf` were previously added as 'defaults', so they could have been overridden by env values before, but not anymore. Could this be an breaking change?

Let me know what you think. This is a WIP, if you are ok with the changes I'll add more tests and documentation.