### PR TITLE
feat(environment): Support nested options in environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -444,9 +444,16 @@ function parse (args, opts) {
     var prefix = typeof envPrefix === 'string' ? envPrefix : ''
     Object.keys(process.env).forEach(function (envVar) {
       if (prefix === '' || envVar.lastIndexOf(prefix, 0) === 0) {
-        var key = camelCase(envVar.substring(prefix.length))
-        if (((configOnly && flags.configs[key]) || !configOnly) && (!(key in argv) || flags.defaulted[key])) {
-          setArg(key, process.env[envVar])
+        // get array of nested keys and convert them to camel case
+        var keys = envVar.split('__').map(function (key, i) {
+          if (i === 0) {
+            key = key.substring(prefix.length)
+          }
+          return camelCase(key)
+        })
+
+        if (((configOnly && flags.configs[keys.join('.')]) || !configOnly) && (!hasKey(argv, keys) || flags.defaulted[keys.join('.')])) {
+          setArg(keys.join('.'), process.env[envVar])
         }
       }
     })

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1536,6 +1536,39 @@ describe('yargs-parser', function () {
       result.should.have.property('truthy')
       result.z.should.equal(55)
     })
+
+    it('should apply all nested env vars', function () {
+      process.env.TEST_A = 'a'
+      process.env.TEST_NESTED_OPTION__FOO = 'baz'
+      process.env.TEST_NESTED_OPTION__BAR = 'bar'
+      var result = parser(['--nestedOption.foo', 'bar'], {
+        envPrefix: 'TEST'
+      })
+
+      result.should.have.property('a', 'a')
+      result.should.have.property('nestedOption').and.deep.equal({
+        foo: 'bar',
+        bar: 'bar'
+      })
+    })
+
+    it('should apply nested env var if argv value is using default value', function () {
+      process.env.TEST_A = 'a'
+      process.env.TEST_NESTED_OPTION__FOO = 'baz'
+      process.env.TEST_NESTED_OPTION__BAR = 'bar'
+      var result = parser([], {
+        envPrefix: 'TEST',
+        default: {
+          'nestedOption.foo': 'banana'
+        }
+      })
+
+      result.should.have.property('a', 'a')
+      result.should.have.property('nestedOption').and.deep.equal({
+        foo: 'baz',
+        bar: 'bar'
+      })
+    })
   })
 
   describe('configuration', function () {


### PR DESCRIPTION
It uses the '__' syntax to indicate nested properties, based on prior art from
https://github.com/indexzero/nconf#env and https://github.com/dominictarr/rc.

Closes yargs/yargs#332