### PR TITLE
Do not parse numbers that evaluate to Infinity

### DIFF
--- a/index.js
+++ b/index.js
@@ -602,7 +602,7 @@ function parse (args, opts) {
     if (!configuration['parse-numbers']) return false
     if (typeof x === 'number') return true
     if (/^0x[0-9a-f]+$/i.test(x)) return true
-    return /^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(x)
+    return /^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(x) && Number(x) !== Infinity
   }
 
   function isUndefined (num) {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -185,6 +185,11 @@ describe('yargs-parser', function () {
     args.should.have.property('s', 'X\nX')
   })
 
+  it('should preserve numbers that evaluate to infinity as strings', function () {
+    var args = parser(['-n', '87e3202'])
+    args.should.have.property('n', '87e3202').and.be.a('string')
+  })
+
   it('should not convert numbers to type number if explicitly defined as strings', function () {
     var s = parser([ '-s', '0001234' ], {
       string: 's'


### PR DESCRIPTION
Some numbers, like `87e3202`, are recognised as numbers by the
isNumber utility, which results on `yargs-parser` parsing them by default
and thus passing a meaningless `Infinity` value to the user.

Since parsing scientific notation numbers are supported on `yargs-parser` as a
feature, the approach of this patch is to only return true from
`isNumber` if the string indeed represents a number, but it doesn't
evaluate to `Infinity` when being parsed as such, therefore not breaking
any existing functionality on the module.

The use case where this bug showed up was passing (shorter) UUIDs as
command line arguments.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>