### PR TITLE
fix: better parsing of negative values

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ function parse (args, opts) {
     nargs: {},
     coercions: {}
   }
+  var negative = /^-[0-9]+(\.[0-9]+)?/
 
   ;[].concat(opts.array).filter(Boolean).forEach(function (key) {
     flags.arrays[key] = true
@@ -155,7 +156,8 @@ function parse (args, opts) {
       } else {
         next = args[i + 1]
 
-        if (next !== undefined && !next.match(/^-/) &&
+        if (next !== undefined && (!next.match(/^-/) ||
+          next.match(negative)) &&
           !checkAllAliases(key, flags.bools) &&
           !checkAllAliases(key, flags.counts)) {
           setArg(key, next)
@@ -186,7 +188,7 @@ function parse (args, opts) {
       } else {
         setArg(key, defaultForType(guessType(key, flags)))
       }
-    } else if (arg.match(/^-[^-]+/)) {
+    } else if (arg.match(/^-[^-]+/) && !arg.match(negative)) {
       letters = arg.slice(1, -1).split('')
       broken = false
 
@@ -247,7 +249,8 @@ function parse (args, opts) {
         } else {
           next = args[i + 1]
 
-          if (next !== undefined && !/^(-|--)[^-]/.test(next) &&
+          if (next !== undefined && (!/^(-|--)[^-]/.test(next) ||
+            next.match(negative)) &&
             !checkAllAliases(key, flags.bools) &&
             !checkAllAliases(key, flags.counts)) {
             setArg(key, next)
@@ -308,7 +311,7 @@ function parse (args, opts) {
   function eatArray (i, key, args) {
     var start = i + 1
     for (var ii = i + 1; ii < args.length; ii++) {
-      if (/^-/.test(args[ii])) {
+      if (/^-/.test(args[ii]) && !negative.test(args[ii])) {
         if (ii === start) {
           setArg(key, defaultForType('array'))
         }

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -127,6 +127,32 @@ describe('yargs-parser', function () {
     argv._[0].should.be.a('number')
   })
 
+  // addresses: https://github.com/yargs/yargs-parser/issues/33
+  it('should handle parsing negative #s', function () {
+    var argv = parser([
+      '-33', '-177', '33',
+      '--n1', '-33',
+      '-n', '-44',
+      '--n2=-55',
+      '--foo.bar', '-33',
+      '-o=-55',
+      '--bounds', '-180', '99', '-180', '90',
+      '--other', '-99', '-220'
+    ], {
+      array: 'bounds',
+      narg: {'other': 2}
+    })
+
+    argv._.should.deep.equal([-33, -177, 33])
+    argv.n1.should.equal(-33)
+    argv.n.should.equal(-44)
+    argv.n2.should.equal(-55)
+    argv.foo.bar.should.equal(-33)
+    argv.o.should.equal(-55)
+    argv.bounds.should.deep.equal([-180, 99, -180, 90])
+    argv.other.should.deep.equal([-99, -220])
+  })
+
   it('should set the value of a single short option to the next supplied value, even if the value is empty', function () {
     var parse = parser(['-p', ''])
     parse.should.have.property('p', '')
@@ -900,13 +926,6 @@ describe('yargs-parser', function () {
       argv.should.have.property('5', true)
       argv.should.have.property('n', 123)
       argv.should.have.property('_').with.length(0)
-    })
-
-    it('should set option "1" to true, option "2" to true, and option "3" to numeric value 456', function () {
-      var argv = parser([ '-123', '456' ])
-      argv.should.have.property('1', true)
-      argv.should.have.property('2', true)
-      argv.should.have.property('3', 456)
     })
   })
 


### PR DESCRIPTION
this should be considered a breaking change, as we can no longer define argument groups like `-123`; however let's simply amend the `3.x` release (since we haven't published the package yet).

fixes: #33 
