### PR TITLE
refactor: expect coerce functions to be synchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Parses command line arguments returning a simple mapping of keys and values.
   * `opts.array`: indicate that keys should be parsed as an array: `{array: ['foo', 'bar']}`.
   * `opts.boolean`: arguments should be parsed as booleans: `{boolean: ['x', 'y']}`.
   * `opts.config`: indicate a key that represents a path to a configuration file (this file will be loaded and parsed).
-  * `opts.coerce`: provide a custom function to coerce a value from the argument provided,
-    e.g., `{coerce: {foo: function (arg, cb) {return cb(err, modifiedArg)}}}`.
+  * `opts.coerce`: provide a custom synchronous function that returns a coerced value from the argument provided
+    (or throws an error), e.g. `{coerce: {foo: function (arg) {return modifiedArg}}}`.
   * `opts.count`: indicate a key that should be used as a counter, e.g., `-vvv` = `{v: 3}`.
   * `opts.default`: provide default values for keys: `{default: {x: 33, y: 'hello world!'}}`.
   * `opts.envPrefix`: environment variables (`process.env`) with the prefix provided should be parsed.

--- a/index.js
+++ b/index.js
@@ -521,11 +521,12 @@ function parse (args, opts) {
 
     var key = keys[keys.length - 1]
     var coerce = checkAllAliases(key, flags.coercions)
-    if (coerce) {
-      coerce(value, function (err, val) {
+    if (typeof coerce === 'function') {
+      try {
+        value = coerce(value)
+      } catch (err) {
         error = err
-        value = val
-      })
+      }
     }
 
     if (value === increment) {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1957,8 +1957,8 @@ describe('yargs-parser', function () {
     it('applies coercion function to simple arguments', function () {
       var parsed = parser(['--foo', '99'], {
         coerce: {
-          foo: function (arg, cb) {
-            return cb(null, arg * -1)
+          foo: function (arg) {
+            return arg * -1
           }
         }
       })
@@ -1968,8 +1968,8 @@ describe('yargs-parser', function () {
     it('applies coercion function to aliases', function () {
       var parsed = parser(['--foo', '99'], {
         coerce: {
-          f: function (arg, cb) {
-            return cb(null, arg * -1)
+          f: function (arg) {
+            return arg * -1
           }
         },
         alias: {
@@ -1983,8 +1983,8 @@ describe('yargs-parser', function () {
     it('applies coercion function to an array', function () {
       var parsed = parser(['--foo', '99', '-f', '33'], {
         coerce: {
-          f: function (arg, cb) {
-            return cb(null, arg * -1)
+          f: function (arg) {
+            return arg * -1
           }
         },
         array: ['foo'],
@@ -1998,9 +1998,9 @@ describe('yargs-parser', function () {
 
     // see: https://github.com/yargs/yargs/issues/550
     it('coercion function can be used to parse large #s', function () {
-      var fancyNumberParser = function (arg, cb) {
-        if (arg.length > 10) return cb(null, arg)
-        else return cb(null, parseInt(arg))
+      var fancyNumberParser = function (arg) {
+        if (arg.length > 10) return arg
+        else return parseInt(arg)
       }
       var parsed = parser(['--foo', '88888889999990000998989898989898', '--bar', '998'], {
         coerce: {
@@ -2017,8 +2017,8 @@ describe('yargs-parser', function () {
     it('populates argv.error, if an error is returned', function () {
       var parsed = parser.detailed(['--foo', '99'], {
         coerce: {
-          foo: function (arg, cb) {
-            return cb(Error('banana'), arg * -1)
+          foo: function (arg) {
+            throw Error('banana')
           }
         }
       })


### PR DESCRIPTION
Expect a coercion function to return or throw instead of calling a callback, to avoid any ambiguity that async functions might be supported.