### PR TITLE
docs: clarify args as array of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Build Status](https://travis-ci.org/yargs/yargs-parser.png)](https://travis-ci.org/yargs/yargs-parser)
 [![Coverage Status](https://coveralls.io/repos/yargs/yargs-parser/badge.svg?branch=)](https://coveralls.io/r/yargs/yargs-parser?branch=master)
 [![NPM version](https://img.shields.io/npm/v/yargs-parser.svg)](https://www.npmjs.com/package/yargs-parser)
-[![Windows Tests](https://img.shields.io/appveyor/ci/bcoe/yargs-parser/master.svg?label=Windows%20Tests)](https://ci.appveyor.com/project/bcoe/yargs-parser)
+[![Windows Tests](https://img.shields.io/appveyor/ci/yargs/yargs-parser/master.svg?label=Windows%20Tests)](https://ci.appveyor.com/project/yargs/yargs-parser)
 [![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
 
 
-The mighty option parser used by [yargs](https://github.com/bcoe/yargs).
+The mighty option parser used by [yargs](https://github.com/yargs/yargs).
 
 visit the [yargs website](http://yargs.js.org/) for more examples, and thorough usage instructions.
 
@@ -20,7 +20,7 @@ npm i yargs-parser --save
 ```
 
 ```js
-var argv = require('yargs-parser')(process.argv.slice(2));
+var argv = require('yargs-parser')(process.argv.slice(2))
 console.log(argv)
 ```
 
@@ -32,12 +32,20 @@ node example.js --foo=33 --bar hello
 _or parse a string!_
 
 ```js
-var argv = require('./')('--foo=99 --bar=33');
+var argv = require('./')('--foo=99 --bar=33')
 console.log(argv)
 ```
 
 ```sh
 { _: [], foo: 99, bar: 33 }
+```
+
+Convert an array of mixed types before passing to `yargs-parser`:
+
+```js
+var parse = require('yargs-parser')
+parse(['-f', 11, '--zoom', 55].join(' '))   // <-- array to string
+parse(['-f', 11, '--zoom', 55].map(String)) // <-- array of strings
 ```
 
 ## API
@@ -48,7 +56,7 @@ Parses command line arguments returning a simple mapping of keys and values.
 
 **expects:**
 
-* `args`: an array or string representing the options to parse.
+* `args`: a string or array of strings representing the options to parse.
 * `opts`: provide a set of hints indicating how `args` should be parsed:
   * `opts.alias`: an object representing the set of aliases for a key: `{alias: {foo: ['f']}}`.
   * `opts.array`: indicate that keys should be parsed as an array: `{array: ['foo', 'bar']}`.
@@ -78,7 +86,7 @@ yargs engine.
 
 **expects:**
 
-* `args`: an array or string representing options to parse.
+* `args`: a string or array of strings representing options to parse.
 * `opts`: provide a set of hints indicating how `args`, inputs are identical to `require('yargs-parser')(args, opts={})`.
 
 **returns:**


### PR DESCRIPTION
And other minor cleanup.

Closes #46.