### PR TITLE
feat: coerce full array instead of each element

### DIFF
--- a/index.js
+++ b/index.js
@@ -486,7 +486,7 @@ function parse (args, opts) {
   function applyArrayCoercions (argv) {
     var coerce
     Object.keys(argv).filter(function (key) {
-      return checkAllAliases(key, flags.arrays)
+      return key === '_' || checkAllAliases(key, flags.arrays)
     }).forEach(function (key) {
       coerce = checkAllAliases(key, flags.coercions)
       if (typeof coerce === 'function') {

--- a/index.js
+++ b/index.js
@@ -280,6 +280,7 @@ function parse (args, opts) {
   setConfig(argv)
   setConfigObjects()
   applyEnvVars(argv, false)
+  applyArrayCoercions(argv)
   applyDefaultsAndAliases(argv, flags.aliases, defaults)
 
   // for any counts either not in args or without an explicit default, set to 0
@@ -482,6 +483,22 @@ function parse (args, opts) {
     })
   }
 
+  function applyArrayCoercions (argv) {
+    var coerce
+    Object.keys(argv).filter(function (key) {
+      return checkAllAliases(key, flags.arrays)
+    }).forEach(function (key) {
+      coerce = checkAllAliases(key, flags.coercions)
+      if (typeof coerce === 'function') {
+        try {
+          argv[key] = coerce(argv[key])
+        } catch (err) {
+          error = err
+        }
+      }
+    })
+  }
+
   function applyDefaultsAndAliases (obj, aliases, defaults) {
     Object.keys(defaults).forEach(function (key) {
       if (!hasKey(obj, key.split('.'))) {
@@ -521,7 +538,7 @@ function parse (args, opts) {
     })
 
     var key = keys[keys.length - 1]
-    var coerce = checkAllAliases(key, flags.coercions)
+    var coerce = !checkAllAliases(key, flags.arrays) && checkAllAliases(key, flags.coercions)
     if (typeof coerce === 'function') {
       try {
         value = coerce(value)

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1980,11 +1980,28 @@ describe('yargs-parser', function () {
       parsed.f.should.equal(-99)
     })
 
-    it('applies coercion function to an array', function () {
+    it('applies coercion function to an implicit array', function () {
       var parsed = parser(['--foo', '99', '-f', '33'], {
         coerce: {
           f: function (arg) {
             return arg * -1
+          }
+        },
+        alias: {
+          f: ['foo']
+        }
+      })
+      parsed.f.should.deep.equal([-99, -33])
+      parsed.foo.should.deep.equal([-99, -33])
+    })
+
+    it('applies coercion function to an explicit array', function () {
+      var parsed = parser(['--foo', '99', '-f', '33'], {
+        coerce: {
+          f: function (arg) {
+            return arg.map(function (a) {
+              return a * -1
+            })
           }
         },
         array: ['foo'],
@@ -2014,7 +2031,7 @@ describe('yargs-parser', function () {
       parsed.bar.should.equal(998)
     })
 
-    it('populates argv.error, if an error is returned', function () {
+    it('populates argv.error, if an error is thrown', function () {
       var parsed = parser.detailed(['--foo', '99'], {
         coerce: {
           foo: function (arg) {
@@ -2023,6 +2040,18 @@ describe('yargs-parser', function () {
         }
       })
       parsed.error.message.should.equal('banana')
+    })
+
+    it('populates argv.error, if an error is thrown for an explicit array', function () {
+      var parsed = parser.detailed(['--foo', '99'], {
+        array: ['foo'],
+        coerce: {
+          foo: function (arg) {
+            throw Error('foo is array: ' + Array.isArray(arg))
+          }
+        }
+      })
+      parsed.error.message.should.equal('foo is array: true')
     })
   })
 

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2013,6 +2013,19 @@ describe('yargs-parser', function () {
       parsed.foo.should.deep.equal([-99, -33])
     })
 
+    it('applies coercion function to _', function () {
+      var parsed = parser(['99', '33'], {
+        coerce: {
+          _: function (arg) {
+            return arg.map(function (a) {
+              return a * -1
+            })
+          }
+        }
+      })
+      parsed._.should.deep.equal([-99, -33])
+    })
+
     // see: https://github.com/yargs/yargs/issues/550
     it('coercion function can be used to parse large #s', function () {
       var fancyNumberParser = function (arg) {


### PR DESCRIPTION
Fixes #50.

As a bonus, this also means coercion can apply to `argv._`. Here's an example:

```js
var parse = require('yargs-parser')
var argv = parse(process.argv.slice(2), {
  coerce: {
    _: function (arg) {
      // do something special here
      return arg
    }
  }
})
console.log(argv)
```

This works with an explicit `string: ['_']` option too (the coerce function would be guaranteed to be given an array of strings).

Note that coercion for implicit arrays (options parsed with multiple values but without `array` config) still happens per element.