### PR TITLE
feature: remove deprecated dependency lodas.assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var assign = require('lodash.assign')
+var assign = require('object-assign')
 var camelCase = require('camelcase')
 var path = require('path')
 var tokenizeArgString = require('./lib/tokenize-arg-string')
@@ -11,7 +11,7 @@ function parse (args, opts) {
   args = tokenizeArgString(args)
   // aliases might have transitive relationships, normalize this.
   var aliases = combineAliases(opts.alias || {})
-  var configuration = assign({}, {
+  var configuration = assign({
     'short-option-groups': true,
     'camel-case-expansion': true,
     'dot-notation': true,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "camelcase": "^3.0.0",
-    "lodash.assign": "^4.1.0"
+    "object-assign": "^4.1.0"
   },
   "files": [
     "lib",


### PR DESCRIPTION
When I install `yargs-parser` I see this warning:

`npm WARN deprecated lodash.assign@4.2.0: This package is deprecated. Use Object.assign.`

So I replaced `lodash.assign` with [object-assign](https://github.com/sindresorhus/object-assign).

`lodash` documentation [says](https://lodash.com/docs/4.16.2#assign):

```
This method mutates object and is loosely based on Object.assign.
```