### PR TITLE
fix: handle dot notation boolean options

### DIFF
--- a/index.js
+++ b/index.js
@@ -540,7 +540,7 @@ function parse (args, opts) {
       o[key] = increment(o[key])
     } else if (o[key] === undefined && checkAllAliases(key, flags.arrays)) {
       o[key] = Array.isArray(value) ? value : [value]
-    } else if (o[key] === undefined || checkAllAliases(key, flags.bools) || checkAllAliases(key, flags.counts)) {
+    } else if (o[key] === undefined || checkAllAliases(key, flags.bools) || checkAllAliases(keys.join('.'), flags.bools) || checkAllAliases(key, flags.counts)) {
       o[key] = value
     } else if (Array.isArray(o[key])) {
       o[key].push(value)

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -198,6 +198,18 @@ describe('yargs-parser', function () {
     parse.should.have.property('_').and.deep.equal(['one', 'two', 'three'])
   })
 
+  it('should correctly parse dot-notation boolean flags', function () {
+    var parse = parser(['--nested', '--n.v', '--n.y', 'foo'], {
+      boolean: ['nested', 'n.v']
+    })
+
+    parse.should.have.property('nested', true).and.be.a('boolean')
+    parse.should.have.property('n').and.deep.equal({
+      v: true,
+      y: 'foo'
+    })
+  })
+
   it('should preserve newlines in option values', function () {
     var args = parser(['-s', 'X\nX'])
     args.should.have.property('_').with.length(0)


### PR DESCRIPTION
Fixes yargs/yargs#617

On studying the code I found that this bug is being caused by yargs-parser. I think my fix should solve this issue, though I'm not sure if something else breaks because of these changes.

I've tested this modified library with yargs and found that all test cases pass.
