### PR TITLE
feat: allow disabling duplicate-arguments-array

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ function parse (args, opts) {
     'camel-case-expansion': true,
     'dot-notation': true,
     'parse-numbers': true,
-    'boolean-negation': true
+    'boolean-negation': true,
+    'duplicate-arguments-array': true
   }, opts.configuration)
   var defaults = opts.default || {}
   var configObjects = opts.configObjects || []
@@ -544,8 +545,10 @@ function parse (args, opts) {
       o[key] = value
     } else if (Array.isArray(o[key])) {
       o[key].push(value)
-    } else {
+    } else if (configuration['duplicate-arguments-array']) {
       o[key] = [ o[key], value ]
+    } else {
+      o[key] = value
     }
   }
 

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1933,6 +1933,27 @@ describe('yargs-parser', function () {
         expect(parsed.dice).to.equal(undefined)
       })
     })
+
+    describe('duplicate arguments array', function () {
+      it('adds duplicate argument to array', function () {
+        var parsed = parser('-x a -x b', {
+          configuration: {
+            'duplicate-arguments-array': true
+          }
+        })
+
+        parsed['x'].should.deep.equal(['a', 'b'])
+      })
+      it('keeps only last argument', function () {
+        var parsed = parser('-x a -x b', {
+          configuration: {
+            'duplicate-arguments-array': false
+          }
+        })
+
+        parsed['x'].should.equal('b')
+      })
+    })
   })
 
   // addresses: https://github.com/yargs/yargs-parser/issues/41


### PR DESCRIPTION
For [yargs#530](https://github.com/yargs/yargs/issues/530)

Lets you disable "duplicates" behaviour

```
yargsParser('-x 1 -x 2')
// => {x: [1, 2]}
```
```
yargsParser('-x 1 -x 2', {configuration:{'duplicate-arguments-array': false}})
// => {x: 2}
```


