### PR TITLE
 	feat: allow not to flatten duplicate array types

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ function parse (args, opts) {
     'camel-case-expansion': true,
     'dot-notation': true,
     'parse-numbers': true,
-    'boolean-negation': true
+    'boolean-negation': true,
+    'duplicate-arguments-array': true
   }, opts.configuration)
   var defaults = opts.default || {}
   var configObjects = opts.configObjects || []
@@ -544,8 +545,10 @@ function parse (args, opts) {
       o[key] = value
     } else if (Array.isArray(o[key])) {
       o[key].push(value)
-    } else {
+    } else if (configuration['duplicate-arguments-array']) {
       o[key] = [ o[key], value ]
+    } else {
+      o[key] = value
     }
   }
 

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1954,6 +1954,39 @@ describe('yargs-parser', function () {
         parsed['x'].should.equal('b')
       })
     })
+
+    describe('flatten duplicate arrays', function () {
+      it('flattens duplicate array type', function () {
+        var parsed = parser('-x a b -x c d', {
+          array: ['x'],
+          configuration: {
+            'flatten-duplicate-arrays': true
+          }
+        })
+
+        parsed['x'].should.deep.equal(['a', 'b', 'c', 'd'])
+      })
+      it('nests duplicate array types', function () {
+        var parsed = parser('-x a b -x c d', {
+          array: ['x'],
+          configuration: {
+            'flatten-duplicate-arrays': false
+          }
+        })
+
+        parsed['x'].should.deep.equal([['a', 'b'], ['c', 'd']])
+      })
+      it('doesn\'t nests single arrays', function () {
+        var parsed = parser('-x a b', {
+          array: ['x'],
+          configuration: {
+            'flatten-duplicate-arrays': false
+          }
+        })
+
+        parsed['x'].should.deep.equal(['a', 'b'])
+      })
+    })
   })
 
   // addresses: https://github.com/yargs/yargs-parser/issues/41

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1933,6 +1933,27 @@ describe('yargs-parser', function () {
         expect(parsed.dice).to.equal(undefined)
       })
     })
+
+    describe('duplicate arguments array', function () {
+      it('adds duplicate argument to array', function () {
+        var parsed = parser('-x a -x b', {
+          configuration: {
+            'duplicate-arguments-array': true
+          }
+        })
+
+        parsed['x'].should.deep.equal(['a', 'b'])
+      })
+      it('keeps only last argument', function () {
+        var parsed = parser('-x a -x b', {
+          configuration: {
+            'duplicate-arguments-array': false
+          }
+        })
+
+        parsed['x'].should.equal('b')
+      })
+    })
   })
 
   // addresses: https://github.com/yargs/yargs-parser/issues/41


### PR DESCRIPTION
Lets you disable flattening of multiple array type values

```
yargsParser('-x a b -x c d', {array: ['x]})
// => {x: ['a', 'b', 'c', 'd']} // all flattened
```
```
yargsParser('-x a b -x c d', {array: ['x], configuration:{'flatten-duplicate-arrays': false}})
// => {x: [['a', 'b'], ['c', 'd']]} // multiple nested arrays
```
```
yargsParser('-x a b', {array: ['x], configuration:{'flatten-duplicate-arrays': false}})
// => {x: ['a', 'b']} // still a flat single array when no duplicates
```

fixes [yargs#688](https://github.com/yargs/yargs/issues/688)

includes #67