### PR TITLE
fix: inner objects in configs had their keys appended to top-level key when dot-notation was disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -440,7 +440,10 @@ function parse (args, opts) {
       var value = config[key]
       var fullKey = prev ? prev + '.' + key : key
 
-      if (Object.prototype.toString.call(value) === '[object Object]') {
+      // if the value is an inner object and we have dot-notation
+      // enabled, treat inner objects in config the same as
+      // heavily nested dot notations (foo.bar.apple).
+      if (typeof value === 'object' && !Array.isArray(value) && configuration['dot-notation']) {
         // if the value is an object but not an array, check nested object
         setConfigObject(value, fullKey)
       } else {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1886,6 +1886,31 @@ describe('yargs-parser', function () {
         expect(parsed['foo.bar']).to.equal('banana')
         expect(parsed).not.to.include.keys('f.bar')
       })
+
+      // addresses https://github.com/yargs/yargs/issues/716
+      it('does not append nested-object keys from config to top-level key', function () {
+        var parsed = parser([], {
+          alias: {
+            'foo': ['f']
+          },
+          configuration: {
+            'dot-notation': false
+          },
+          configObjects: [
+            {
+              'website.com': {
+                a: 'b',
+                b: 'c'
+              }
+            }
+          ]
+        })
+
+        parsed['website.com'].should.deep.equal({
+          a: 'b',
+          b: 'c'
+        })
+      })
     })
 
     describe('parse numbers', function () {


### PR DESCRIPTION
edge case discussed in https://github.com/yargs/yargs/issues/716