### PR TITLE
Also flatten-duplicate-arrays when used with dot-notation

### DIFF
--- a/index.js
+++ b/index.js
@@ -556,9 +556,16 @@ function parse (args, opts) {
       o = o[key]
     })
 
+    var fullKey = []
+    if (configuration['flatten-duplicate-arrays'] && keys.length > 1) {
+      fullKey.push(keys.join('.'))
+    } else {
+      fullKey.push(keys[keys.length - 1])
+    }
+
     var key = keys[keys.length - 1]
 
-    var isTypeArray = checkAllAliases(key, flags.arrays)
+    var isTypeArray = checkAllAliases(fullKey, flags.arrays)
     var isValueArray = Array.isArray(value)
     var duplicate = configuration['duplicate-arguments-array']
 

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2016,6 +2016,16 @@ describe('yargs-parser', function () {
 
         parsed['x'].should.deep.equal(['a', 'b'])
       })
+      it('flattens duplicate array type with dot notations', function () {
+        var parsed = parser('-x.foo a -x.foo b', {
+          array: ['x.foo'],
+          configuration: {
+            'flatten-duplicate-arrays': true
+          }
+        })
+
+        parsed['x'].should.deep.equal({foo: ['a', 'b']})
+      })
     })
 
     describe('duplicate-arguments-array VS flatten-duplicate-arrays', function () {


### PR DESCRIPTION
Background: https://github.com/yargs/yargs/issues/777

When using dot-notations I also want arrays to be flattened. This was the behaviour in Yargs 5 but not anymore in Yargs 6.

```
# GOOD
$ node good-yargs-parser.js --metric.list AA --metric.list BB --metricList CC --metricList DD
{ _: [],
  metric: { list: [ 'AA', 'BB' ] },
  metricList: [ 'CC', 'DD' ],
  '$0': 'yargstest.js' }

# BAD
$ node bad-yargs-parser.js --metric.list AA --metric.list BB --metricList CC --metricList DD
{ _: [],
  metric: { list: [ 'AA', ['BB'] ] },
  metricList: [ 'CC', 'DD' ],
  '$0': 'yargstest.js' }
```