### PR TITLE
fix: environment variables should take precedence over config file

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,14 +273,14 @@ function parse (args, opts) {
 
   // order of precedence:
   // 1. command line arg
-  // 2. value from config file
-  // 3. value from config objects
-  // 4. value from env var
+  // 2. value from env var
+  // 3. value from config file
+  // 4. value from config objects
   // 5. configured default value
   applyEnvVars(argv, true) // special case: check env vars that point to config file
+  applyEnvVars(argv, false)
   setConfig(argv)
   setConfigObjects()
-  applyEnvVars(argv, false)
   applyDefaultsAndAliases(argv, flags.aliases, defaults)
   applyCoercions(argv)
 

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1697,7 +1697,7 @@ describe('yargs-parser', function () {
     })
 
     var jsonPath = path.resolve(__dirname, './fixtures/config.json')
-    it('should prefer config file value over env var', function () {
+    it('should prefer environment variables over config file', function () {
       process.env.CFG_HERP = 'zerp'
       var result = parser(['--cfg', jsonPath], {
         envPrefix: 'CFG',
@@ -1708,7 +1708,7 @@ describe('yargs-parser', function () {
         }
       })
 
-      result.herp.should.equal('derp')
+      result.herp.should.equal('zerp')
     })
 
     it('should support an env var value as config file option', function () {


### PR DESCRIPTION
BREAKING CHANGE: environment variables now take precedence over config file values.

see: https://github.com/yargs/yargs/issues/627

CC: @jaridmargolin