### PR TITLE
chore: drop support for Node 0.10/0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: node_js
 os:
   - linux
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4.1"
+  - "4"
+  - "6"
   - "node"
 after_script: npm run coverage
 deploy:


### PR DESCRIPTION
as promised, we're going to be dropping Node 0.10/0.12 support in yargs@8.