### PR TITLE
feat: when parsing stops, we now populate "--" by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,23 +103,6 @@ yargs engine.
 
 <a name="configuration"></a>
 
-### Options
-
-#### `--`
-* default: `false`.
-
-_If disabled:_
-```sh
-node example.js a -b -- x y
-{ _: [ 'a', 'x', 'y' ], b: true }
-```
-
-_If enabled:_
-
-```sh
-node example.js a -b -- x y
-{ _: [ 'a' ], '--': [ 'x', 'y' ], b: true }
-```
 ### Configuration
 
 The yargs-parser applies several automated transformations on the keys provided
@@ -265,6 +248,25 @@ _if disabled:_
 ```sh
 node example.js -x 1 2 -x 3 4
 { _: [], x: [[1, 2], [3, 4]] }
+```
+
+### `populate--`
+
+* default: `true`.
+
+Should unparsed flags be stored in `--` or `_`.
+
+_If disabled:_
+```sh
+node example.js a -b -- x y
+{ _: [ 'a', 'x', 'y' ], b: true }
+```
+
+_If enabled:_
+
+```sh
+node example.js a -b -- x y
+{ _: [ 'a' ], '--': [ 'x', 'y' ], b: true }
 ```
 
 ## Special Thanks

--- a/index.js
+++ b/index.js
@@ -17,12 +17,13 @@ function parse (args, opts) {
     'parse-numbers': true,
     'boolean-negation': true,
     'duplicate-arguments-array': true,
-    'flatten-duplicate-arrays': true
+    'flatten-duplicate-arrays': true,
+    'populate--': true
   }, opts.configuration)
   var defaults = opts.default || {}
   var configObjects = opts.configObjects || []
   var envPrefix = opts.envPrefix
-  var notFlagsOption = opts['--']
+  var notFlagsOption = configuration['populate--']
   var notFlagsArgv = notFlagsOption ? '--' : '_'
   var newAliases = {}
   // allow a i18n handler to be passed in, default to a fake one (util.format).

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2228,9 +2228,7 @@ describe('yargs-parser', function () {
           '--key', 'value',
           '-b', '--bool', '--no-meep', '--multi=baz',
           '--', '--not-a-flag', '-', '-h', '-multi', '--', 'eek'
-        ], {
-          '--': true
-        })
+        ])
         result.should.have.property('c', true)
         result.should.have.property('a', true)
         result.should.have.property('t', true)

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -94,7 +94,11 @@ describe('yargs-parser', function () {
       '--key', 'value',
       '-b', '--bool', '--no-meep', '--multi=baz',
       '--', '--not-a-flag', '-', '-h', '-multi', '--', 'eek'
-    ])
+    ], {
+      configuration: {
+        'populate--': false
+      }
+    })
     parse.should.have.property('c', true)
     parse.should.have.property('a', true)
     parse.should.have.property('t', true)
@@ -1260,46 +1264,6 @@ describe('yargs-parser', function () {
     })
   })
 
-  describe('option --', function () {
-    describe('when it is not defined', function () {
-      it('should not initialize the \'--\' array', function () {
-        var result = parser([
-          'bare',
-          '--', '-h', 'eek', '--'
-        ])
-        result.should.have.property('_').and.deep.equal(['bare', '-h', 'eek', '--'])
-        result.should.not.have.property('--')
-      })
-    })
-
-    describe('when it is defined', function () {
-      it('should set bare flags to \'_\' array and non-flags to \'--\' array', function () {
-        var result = parser([
-          '--name=meowmers', 'bare', '-cats', 'woo', 'moxy',
-          '-h', 'awesome', '--multi=quux',
-          '--key', 'value',
-          '-b', '--bool', '--no-meep', '--multi=baz',
-          '--', '--not-a-flag', '-', '-h', '-multi', '--', 'eek'
-        ], {
-          '--': true
-        })
-        result.should.have.property('c', true)
-        result.should.have.property('a', true)
-        result.should.have.property('t', true)
-        result.should.have.property('s', 'woo')
-        result.should.have.property('h', 'awesome')
-        result.should.have.property('b', true)
-        result.should.have.property('bool', true)
-        result.should.have.property('key', 'value')
-        result.should.have.property('multi').and.deep.equal(['quux', 'baz'])
-        result.should.have.property('meep', false)
-        result.should.have.property('name', 'meowmers')
-        result.should.have.property('_').and.deep.equal(['bare', 'moxy'])
-        result.should.have.property('--').and.deep.equal(['--not-a-flag', '-', '-h', '-multi', '--', 'eek'])
-      })
-    })
-  })
-
   describe('count', function () {
     it('should count the number of times a boolean is present', function () {
       var parsed
@@ -2242,6 +2206,44 @@ describe('yargs-parser', function () {
             parsed['x'].should.deep.equal([1, 2, 3])
           })
         })
+      })
+    })
+
+    describe('populate--', function () {
+      it('should populate "_" if "populate-- false', function () {
+        var result = parser([
+          'bare',
+          '--', '-h', 'eek', '--'
+        ], {
+          configuration: {'populate--': false}
+        })
+        result.should.have.property('_').and.deep.equal(['bare', '-h', 'eek', '--'])
+        result.should.not.have.property('--')
+      })
+
+      it('should populate the "--" array by default', function () {
+        var result = parser([
+          '--name=meowmers', 'bare', '-cats', 'woo', 'moxy',
+          '-h', 'awesome', '--multi=quux',
+          '--key', 'value',
+          '-b', '--bool', '--no-meep', '--multi=baz',
+          '--', '--not-a-flag', '-', '-h', '-multi', '--', 'eek'
+        ], {
+          '--': true
+        })
+        result.should.have.property('c', true)
+        result.should.have.property('a', true)
+        result.should.have.property('t', true)
+        result.should.have.property('s', 'woo')
+        result.should.have.property('h', 'awesome')
+        result.should.have.property('b', true)
+        result.should.have.property('bool', true)
+        result.should.have.property('key', 'value')
+        result.should.have.property('multi').and.deep.equal(['quux', 'baz'])
+        result.should.have.property('meep', false)
+        result.should.have.property('name', 'meowmers')
+        result.should.have.property('_').and.deep.equal(['bare', 'moxy'])
+        result.should.have.property('--').and.deep.equal(['--not-a-flag', '-', '-h', '-multi', '--', 'eek'])
       })
     })
   })


### PR DESCRIPTION
BREAKING CHANGE: rather than placing arguments in "_", when parsing is stopped via "--"; we now populate an array called "--" by default.

I've changed the configuration option to be named `populate--` rather than `--`; as this better fits with the naming conventions of our other configuration settings.

CC: @ruimarques