### PR TITLE
fix: default '--' to undefined, allowing for smoother transition in yargs

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,10 +101,6 @@ function parse (args, opts) {
 
   var argv = { _: [] }
 
-  if (notFlagsOption) {
-    argv[notFlagsArgv] = []
-  }
-
   Object.keys(flags.bools).forEach(function (key) {
     setArg(key, !(key in defaults) ? false : defaults[key])
     setDefaulted(key)
@@ -296,6 +292,8 @@ function parse (args, opts) {
     if (!hasKey(argv, key.split('.'))) setArg(key, 0)
   })
 
+  // '--' defaults to undefined.
+  if (notFlagsOption && notFlags.length) argv[notFlagsArgv] = []
   notFlags.forEach(function (key) {
     argv[notFlagsArgv].push(key)
   })

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -10,12 +10,14 @@ var path = require('path')
 describe('yargs-parser', function () {
   it('should parse a "short boolean"', function () {
     var parse = parser([ '-b' ])
+    parse.should.not.have.property('--')
     parse.should.have.property('b').to.be.ok.and.be.a('boolean')
     parse.should.have.property('_').with.length(0)
   })
 
   it('should parse a "long boolean"', function () {
     var parse = parser('--bool')
+    parse.should.not.have.property('--')
     parse.should.have.property('bool', true)
     parse.should.have.property('_').with.length(0)
   })
@@ -111,6 +113,16 @@ describe('yargs-parser', function () {
     parse.should.have.property('meep', false)
     parse.should.have.property('name', 'meowmers')
     parse.should.have.property('_').and.deep.equal(['bare', '--not-a-flag', '-', '-h', '-multi', '--', 'eek'])
+  })
+
+  it('should not populate "--" if parsing was not stopped', function () {
+    var parse = parser([ '-b' ])
+    parse.should.not.have.property('--')
+  })
+
+  it('should populate "--" if parsing is stopped', function () {
+    var parse = parser([ '-b', '--', 'foo bar' ])
+    parse.should.have.property('--')
   })
 
   it('should parse numbers appropriately', function () {


### PR DESCRIPTION
we should be defaulting `--` to `undefined`, rather than an empty array; this behavior is closer to how the `array` type works.