### PR TITLE
Do not remove quotes when tokenizing a non-option string

### DIFF
--- a/lib/tokenize-arg-string.js
+++ b/lib/tokenize-arg-string.js
@@ -2,7 +2,7 @@
 module.exports = function (argString) {
   if (Array.isArray(argString)) return argString
 
-  argString = argString.trim();
+  argString = argString.trim()
   var i = 0
   var prevC = null
   var c = null
@@ -24,7 +24,7 @@ module.exports = function (argString) {
     if (c === opening) {
       opening = null
       continue
-    } else if ((c === "'" || c === '"') && !opening && (prevC == ' ' || args[i].startsWith('-'))) {
+    } else if ((c === "'" || c === '"') && !opening && (prevC === ' ' || args[i].startsWith('-'))) {
       opening = c
       continue
     }

--- a/lib/tokenize-arg-string.js
+++ b/lib/tokenize-arg-string.js
@@ -2,12 +2,15 @@
 module.exports = function (argString) {
   if (Array.isArray(argString)) return argString
 
+  argString = argString.trim();
   var i = 0
+  var prevC = null
   var c = null
   var opening = null
   var args = []
 
   for (var ii = 0; ii < argString.length; ii++) {
+    prevC = c
     c = argString.charAt(ii)
 
     // split on spaces unless we're in quotes.
@@ -21,7 +24,7 @@ module.exports = function (argString) {
     if (c === opening) {
       opening = null
       continue
-    } else if ((c === "'" || c === '"') && !opening) {
+    } else if ((c === "'" || c === '"') && !opening && (prevC == ' ' || args[i].startsWith('-'))) {
       opening = c
       continue
     }

--- a/test/tokenize-arg-string.js
+++ b/test/tokenize-arg-string.js
@@ -37,4 +37,12 @@ describe('TokenizeArgString', function () {
     args[1].should.equal('hello \'world\'')
     args[2].should.equal('--bar=foo "bar"')
   })
+
+  // https://github.com/yargs/yargs-parser/issues/93
+  it('does not affect quoted strings when argument is not an option', function () {
+    var args = tokenizeArgString('-q sku="invalid"')
+    args[0].should.equal('-q') // passes
+    args[1].should.equal('sku="invalid"') //fails
+  })
+
 })

--- a/test/tokenize-arg-string.js
+++ b/test/tokenize-arg-string.js
@@ -41,8 +41,7 @@ describe('TokenizeArgString', function () {
   // https://github.com/yargs/yargs-parser/issues/93
   it('does not affect quoted strings when argument is not an option', function () {
     var args = tokenizeArgString('-q sku="invalid"')
-    args[0].should.equal('-q') // passes
-    args[1].should.equal('sku="invalid"') //fails
+    args[0].should.equal('-q')
+    args[1].should.equal('sku="invalid"')
   })
-
 })


### PR DESCRIPTION
Fixes #93 