### PR TITLE
fix: only run coercion functions once, despite aliases. (#76)

### DIFF
--- a/index.js
+++ b/index.js
@@ -513,13 +513,19 @@ function parse (args, opts) {
 
   function applyCoercions (argv) {
     var coerce
+    var applied = {}
     Object.keys(argv).forEach(function (key) {
-      coerce = checkAllAliases(key, flags.coercions)
-      if (typeof coerce === 'function') {
-        try {
-          argv[key] = coerce(argv[key])
-        } catch (err) {
-          error = err
+      if (!applied.hasOwnProperty(key)) { // If we haven't already coerced this option via one of its aliases
+        coerce = checkAllAliases(key, flags.coercions)
+        if (typeof coerce === 'function') {
+          try {
+            var value = coerce(argv[key])
+            ;([].concat(flags.aliases[key] || [], key)).forEach(ali => {
+              applied[ali] = argv[ali] = value
+            })
+          } catch (err) {
+            error = err
+          }
         }
       }
     })

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2429,6 +2429,25 @@ describe('yargs-parser', function () {
       })
       parsed.error.message.should.equal('foo is array: true')
     })
+
+    // see: https://github.com/yargs/yargs-parser/issues/76
+    it('only runs coercion functions once, even with aliases', function () {
+      var runcount = 0
+      var func = (arg) => {
+        runcount++
+        return undefined
+      }
+      parser([ '--foo', 'bar' ], {
+        alias: {
+          foo: ['f', 'foo-bar', 'bar'],
+          b: ['bar']
+        },
+        coerce: {
+          bar: func
+        }
+      })
+      runcount.should.equal(1)
+    })
   })
 
   // see: https://github.com/yargs/yargs-parser/issues/37


### PR DESCRIPTION
Fixes #76 
Fixes yargs/yargs#923