### PR TITLE
.idea directory and package-lock.json are added to .gitignore as it's done in yargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.idea
 .nyc_output
 node_modules
 .DS_Store
+package-lock.json
 ./test/fixtures/package.json


### PR DESCRIPTION
This pull request adds `.idea` directory and `package-lock.json` file to `.gitignore` as it's [done in yargs](https://github.com/yargs/yargs/blob/master/.gitignore).