### PR TITLE
fix: scientific notation circumvented bounds check

### DIFF
--- a/index.js
+++ b/index.js
@@ -425,7 +425,9 @@ function parse (args, opts) {
 
   function maybeCoerceNumber (key, value) {
     if (!checkAllAliases(key, flags.strings) && !checkAllAliases(key, flags.coercions)) {
-      const shouldCoerceNumber = isNumber(value) && configuration['parse-numbers'] && (Number.isSafeInteger(parseInt(value)))
+      const shouldCoerceNumber = isNumber(value) && configuration['parse-numbers'] && (
+        Number.isSafeInteger(Math.floor(value))
+      )
       if (shouldCoerceNumber || (!isUndefined(value) && checkAllAliases(key, flags.numbers))) value = Number(value)
     }
     return value

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2479,6 +2479,11 @@ describe('yargs-parser', function () {
     argv.foo.should.equal('93940495950949399948393')
   })
 
+  it('does not magically convert scientific notation larger than Number.MAX_SAFE_INTEGER', () => {
+    const argv = parser([ '--foo', '33e99999' ])
+    argv.foo.should.equal('33e99999')
+  })
+
   it('converts numeric options larger than Number.MAX_SAFE_INTEGER to number', () => {
     const argv = parser([ '--foo', '93940495950949399948393' ], {
       number: ['foo']


### PR DESCRIPTION
due to a bug in our bounds checking logic, scientific notation could be entered greater than MAX_INTEGER.

fixes: https://github.com/yargs/yargs/issues/1017
see: https://github.com/yargs/yargs/pull/1019