### PR TITLE
feat: make combining arrays a configurable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ node example.js --no-foo
 { _: [], "no-foo": true }
 ```
 
+### combine arrays
+
+* default: `false`
+* key: `combine-arrays`
+
+Should arrays be combined when provided by both command line arguments and
+a configuration file.
+
 ### duplicate arguments array
 
 * default: `true`

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ function parse (args, opts) {
     'negation-prefix': 'no-',
     'duplicate-arguments-array': true,
     'flatten-duplicate-arrays': true,
-    'populate--': false
+    'populate--': false,
+    'combine-arrays': false
   }, opts.configuration)
   var defaults = opts.default || {}
   var configObjects = opts.configObjects || []
@@ -487,7 +488,7 @@ function parse (args, opts) {
       } else {
         // setting arguments via CLI takes precedence over
         // values within the config file.
-        if (!hasKey(argv, fullKey.split('.')) || (flags.defaulted[fullKey]) || (flags.arrays[fullKey])) {
+        if (!hasKey(argv, fullKey.split('.')) || (flags.defaulted[fullKey]) || (flags.arrays[fullKey] && configuration['combine-arrays'])) {
           setArg(fullKey, value)
         }
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "chai": "^3.5.0",
     "coveralls": "^2.11.12",
     "mocha": "^3.0.1",
-    "nyc": "^11.2.1",
+    "nyc": "^11.4.1",
     "standard": "^10.0.2",
     "standard-version": "^4.0.0"
   },

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -456,6 +456,9 @@ describe('yargs-parser', function () {
         array: ['foo'],
         default: {
           settings: jsonPath
+        },
+        configuration: {
+          'combine-arrays': true
         }
       })
 


### PR DESCRIPTION
@markbirbeck went ahead and made this feature configurable; you can enable it on your library by adding a `yargs` stanza to a package.json with `combine-arrays: true`.