### PR TITLE
feat: narg arguments no longer consume flag arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,11 +302,20 @@ function parse (args, opts) {
   // how many arguments should we consume, based
   // on the nargs option?
   function eatNargs (i, key, args) {
+    var ii
     var toEat = checkAllAliases(key, flags.nargs)
 
-    if (args.length - (i + 1) < toEat) error = Error(__('Not enough arguments following: %s', key))
+    // nargs will not consume flag arguments, e.g., -abc, --foo,
+    // and terminates when one is observed.
+    var available = 0
+    for (ii = i + 1; ii < args.length; ii++) {
+      if (!args[ii].match(/^-[^0-9]/)) available++
+      else break
+    }
 
-    for (var ii = i + 1; ii < (toEat + i + 1); ii++) {
+    if (available < toEat) error = Error(__('Not enough arguments following: %s', key))
+
+    for (ii = i + 1; ii < (available + i + 1); ii++) {
       setArg(key, args[ii])
     }
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "the mighty option parser used by yargs",
   "main": "index.js",
   "scripts": {
-    "pretest": "standard",
     "test": "nyc mocha test/*.js",
+    "posttest": "standard",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "release": "standard-version"
   },

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1643,6 +1643,16 @@ describe('yargs-parser', function () {
       result['1'][0].should.equal('a')
       result['1'][1].should.equal('b')
     })
+
+    it('should not treat flag arguments as satisfying narg requirements', function () {
+      var result = parser.detailed(['--foo', '--bar'], {
+        narg: {
+          foo: 1
+        }
+      })
+
+      result.error.message.should.equal('Not enough arguments following: foo')
+    })
   })
 
   describe('env vars', function () {


### PR DESCRIPTION
BREAKING CHANGE: arguments of form --foo, -abc, will no longer be consumed by nargs

This is in prep for replacing the crufty legacy method `requiresArg` with nargs(1).

CC: @evocateur for review