### PR TITLE
fix: do not set boolean flags if not defined in `argv`

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,8 +105,10 @@ function parse (args, opts) {
   var argv = { _: [] }
 
   Object.keys(flags.bools).forEach(function (key) {
-    setArg(key, !(key in defaults) ? false : defaults[key])
-    setDefaulted(key)
+    if (Object.prototype.hasOwnProperty.call(defaults, key)) {
+      setArg(key, defaults[key])
+      setDefaulted(key)
+    }
   })
 
   var notFlags = []

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -199,7 +199,7 @@ describe('yargs-parser', function () {
       boolean: ['x', 'y', 'z']
     })
     parse.should.have.property('x', true).and.be.a('boolean')
-    parse.should.have.property('y', false).and.be.a('boolean')
+    parse.should.not.have.property('y')
     parse.should.have.property('z', true).and.be.a('boolean')
     parse.should.have.property('_').and.deep.equal(['one', 'two', 'three'])
   })
@@ -1101,7 +1101,7 @@ describe('yargs-parser', function () {
         })
 
         it('should set false if no flag in arg', function () {
-          parser([], opts).flag.should.be.false // eslint-disable-line
+          expect(parser([], opts).flag).to.be.undefined // eslint-disable-line
         })
       })
 


### PR DESCRIPTION
Fix #116

`boolean` flags defined without a `default` value will now behave like other option type and won't be set in the parsed results when the user doesn't set the corresponding CLI arg.

Previous behavior:
```js
var parse = require('yargs-parser');

parse('--flag', {boolean: ['flag']});
// => { _: [], flag: true }

parse('--no-flag', {boolean: ['flag']});
// => { _: [], flag: false }

parse('', {boolean: ['flag']});
// => { _: [], flag: false }
```

New behavior:
```js
var parse = require('yargs-parser');

parse('--flag', {boolean: ['flag']});
// => { _: [], flag: true }

parse('--no-flag', {boolean: ['flag']});
// => { _: [], flag: false }

parse('', {boolean: ['flag']});
// => { _: [] } => flag not set similarly to other option type
```