### PR TITLE
feat: add `set-placeholder-key` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,27 @@ node example.js a -b -- x y
 { _: [ 'a' ], '--': [ 'x', 'y' ], b: true }
 ```
 
+### set placeholder key
+
+* default: `false`.
+* key: `set-placeholder-key`.
+
+Should a placeholder be added for keys not set via the corresponding CLI argument?
+
+_If disabled:_
+
+```sh
+node example.js -a 1 -c 2
+{ _: [], a: 1, c: 2 }
+```
+
+_If enabled:_
+
+```sh
+node example.js -a 1 -c 2
+{ _: [], a: 1, b: undefined, c: 2 }
+```
+
 ## Special Thanks
 
 The yargs project evolves from optimist and minimist. It owes its

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2324,6 +2324,65 @@ describe('yargs-parser', function () {
         result.should.have.property('--').and.deep.equal(['--not-a-flag', '-', '-h', '-multi', '--', 'eek'])
       })
     })
+
+    describe('set-placeholder-key', function () {
+      it('should not set placeholder key by default', function () {
+        var parsed = parser([], {
+          string: ['a']
+        })
+        parsed.should.not.have.property('a')
+      })
+
+      it('should set placeholder key to "undefined"', function () {
+        var parsed = parser([], {
+          array: ['a'],
+          boolean: ['b'],
+          string: ['c'],
+          number: ['d'],
+          count: ['e'],
+          normalize: ['f'],
+          narg: {g: 2},
+          coerce: {
+            h: function (arg) {
+              return arg
+            }
+          },
+          configuration: {'set-placeholder-key': true}
+        })
+        parsed.should.have.property('a')
+        expect(parsed.a).to.be.equal(undefined)
+        parsed.should.have.property('b')
+        expect(parsed.b).to.be.equal(undefined)
+        parsed.should.have.property('c')
+        expect(parsed.c).to.be.equal(undefined)
+        parsed.should.have.property('d')
+        expect(parsed.d).to.be.equal(undefined)
+        parsed.should.have.property('e')
+        expect(parsed.f).to.be.equal(undefined)
+        parsed.should.have.property('g')
+        expect(parsed.g).to.be.equal(undefined)
+        parsed.should.have.property('h')
+        expect(parsed.h).to.be.equal(undefined)
+      })
+
+      it('should not set placeholder for key with a default value', function () {
+        var parsed = parser([], {
+          string: ['a'],
+          default: {a: 'hello'},
+          configuration: {'set-placeholder-key': true}
+        })
+        parsed.a.should.equal('hello')
+      })
+
+      it('should not set placeholder key with dot notation', function () {
+        var parsed = parser([], {
+          string: ['a.b']
+        })
+        parsed.should.not.have.property('a')
+        parsed.should.not.have.property('b')
+        parsed.should.not.have.property('a.b')
+      })
+    })
   })
 
   // addresses: https://github.com/yargs/yargs-parser/issues/41


### PR DESCRIPTION
If `true`, add a placeholder for each known key for which the corresponding CLI argument is not set.
The default value for the placeholder is `undefined`.

Follow up to https://github.com/yargs/yargs/pull/1105