### PR TITLE
Coders care 'bout spellin'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ function parse (args, opts) {
     var next
     var value
 
-    // -- seperated by =
+    // -- separated by =
     if (arg.match(/^--.+=/) || (
       !configuration['short-option-groups'] && arg.match(/^-.+=/)
     )) {


### PR DESCRIPTION
Seperate not a word, but separate is.
https://en.oxforddictionaries.com/definition/separate