### PR TITLE
Camel-Case-Expansion: alias by Property names, not Pathes

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,7 +371,10 @@ function parse (args, opts) {
     unsetDefaulted(key)
 
     if (/-/.test(key) && configuration['camel-case-expansion']) {
-      addNewAlias(key, camelCase(key))
+      var alias = key.split('.').map(function (prop) {
+        return camelCase(prop)
+      }).join('.')
+      addNewAlias(key, alias)
     }
 
     var value = processValue(key, val)

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1115,6 +1115,15 @@ describe('yargs-parser', function () {
 
         argv.fooBar.should.equal(99)
       })
+
+      // Fixes: https://github.com/yargs/yargs-parser/issues/77
+      it('should combine dot-notation and camel-case expansion', function () {
+        var argv = parser(['--dot-notation.foo.bar'])
+
+        argv.should.satisfy(function (args) {
+          return args.dotNotation.foo.bar
+        })
+      })
     })
 
     it('should define option as boolean and set default to true', function () {


### PR DESCRIPTION
This fixes issue #77
This *is* a breaking change