### PR TITLE
fix: handling of one char alias as a camelCase

### DIFF
--- a/index.js
+++ b/index.js
@@ -696,7 +696,7 @@ function parse (args, opts) {
         })
         // For "--optionName", also set argv['option-name']
         flags.aliases[key].concat(key).forEach(function (x) {
-          if (/[A-Z]/.test(x) && configuration['camel-case-expansion']) {
+          if (x.length > 1 && /[A-Z]/.test(x) && configuration['camel-case-expansion']) {
             var c = decamelize(x, '-')
             if (c !== key && flags.aliases[key].indexOf(c) === -1) {
               flags.aliases[key].push(c)

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1218,6 +1218,21 @@ describe('yargs-parser', function () {
         result.should.have.property('someOption', 'asdf')
       })
 
+      it('should not apply camel-case logic to 1-character options', function () {
+        var result = parser(['-p', 'hello'], {
+          alias: {
+            p: 'parallel',
+            P: 'parallel-series'
+          }
+        })
+
+        result.should.not.have.property('P', 'hello')
+        result.should.not.have.property('parallel-series', 'hello')
+        result.should.not.have.property('parallelSeries', 'hello')
+        result.should.have.property('parallel', 'hello')
+        result.should.have.property('p', 'hello')
+      })
+
       it('should provide aliases of options with dashes as camelCase properties', function () {
         var result = parser([], {
           alias: {


### PR DESCRIPTION
Hi, thank you for a great library :).

I'm using `yargs-parser` in a lot projects, one of them is [redrun](https://github.com/coderaiser/redrun) (CLI tool to run multiple npm-scripts fast). It has a couple 1 char aliases:

```
Usage: redrun [...tasks] [options] [-- ...args]
Options:
  -p, --parallel          run scripts in parallel
  -P, --parallel-calm     run scripts in parallel and return zero exit code
```

After updating to [v11.0.0](https://github.com/yargs/yargs-parser/blob/master/CHANGELOG.md#1100-2018-10-06) some of [my tests has failed](https://github.com/coderaiser/redrun/blob/v7.0.0/test/redrun.js#L273-L282), here is [parsing](https://github.com/coderaiser/redrun/blob/v7.0.0/lib/cli-parse.js#L61-L95): 

```js
const yargsParser = require('yargs-parser');
const result = yargsParser(['-p', 't*'], {
   array: [
     'parallel',
     'parallel-calm'
  ],
  alias: {
    'p': 'parallel',
    'P': 'parallel-calm'
  },
});

console.log(result);
```
And result:

```js
{ _: [],
  p: [ 't*' ],
  P: [ 't*' ],
  'parallel-calm': [ 't*' ],
  parallelCalm: [ 't*' ],
  parallel: [],
}
```

the reason was `yargs-parser` handled `p` the same as `P` and `parallel-calm`, but it is `parallel`, actually.

The bug is located in condition of [extendAliases](https://github.com/yargs/yargs-parser/blob/v11.0.0/index.js#L699) function:

```js
if (/[A-Z]/.test(x) && configuration['camel-case-expansion']) {
  var c = decamelize(x, '-')
   if (c !== key && flags.aliases[key].indexOf(c) === -1) {
     flags.aliases[key].push(c)
     newAliases[c] = true
   }
}
```

Which is not makes check of the length of an `x`, so single char became a `camelCase` so I added such check.