### PR TITLE
Ensure empty string is added into argv._

### DIFF
--- a/lib/tokenize-arg-string.js
+++ b/lib/tokenize-arg-string.js
@@ -17,6 +17,7 @@ module.exports = function (argString) {
     // split on spaces unless we're in quotes.
     if (c === ' ' && !opening) {
       if (!(prevC === ' ')) {
+        if (!args[i]) args[i] = ''
         i++
       }
       continue

--- a/lib/tokenize-arg-string.js
+++ b/lib/tokenize-arg-string.js
@@ -17,7 +17,6 @@ module.exports = function (argString) {
     // split on spaces unless we're in quotes.
     if (c === ' ' && !opening) {
       if (!(prevC === ' ')) {
-        if (!args[i]) args[i] = ''
         i++
       }
       continue
@@ -26,6 +25,7 @@ module.exports = function (argString) {
     // don't split the string if we're in matching
     // opening or closing single and double quotes.
     if (c === opening) {
+      if (!args[i]) args[i] = ''
       opening = null
       continue
     } else if ((c === "'" || c === '"') && !opening) {

--- a/test/tokenize-arg-string.js
+++ b/test/tokenize-arg-string.js
@@ -32,6 +32,20 @@ describe('TokenizeArgString', function () {
     args[2].should.equal('--bar=foo bar')
   })
 
+  it('handles single quoted empty string', function () {
+    var args = tokenizeArgString('--foo \'\' --bar=\'\'')
+    args[0].should.equal('--foo')
+    args[1].should.equal('')
+    args[2].should.equal('--bar=')
+  })
+
+  it('handles double quoted empty string', function () {
+    var args = tokenizeArgString('--foo "" --bar=""')
+    args[0].should.equal('--foo')
+    args[1].should.equal('')
+    args[2].should.equal('--bar=')
+  })
+
   it('handles quoted string with embeded quotes', function () {
     var args = tokenizeArgString('--foo "hello \'world\'" --bar=\'foo "bar"\'')
     args[0].should.equal('--foo')


### PR DESCRIPTION
A string such as "hello '' world" would parse into ["hello", undefined, "world"].
This would add a catch for that, ensuring that an empty string is pushed
instead, and adds associated tests.