### PR TITLE
add test for config object priority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .DS_Store
 package-lock.json
 ./test/fixtures/package.json
+coverage

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -747,6 +747,20 @@ describe('yargs-parser', function () {
         bar: 'bar'
       })
     })
+
+    it('should load objects with first object having greatest priority', function () {
+      var argv = parser(['--foo', 'bar'], {
+        configObjects: [{
+          bar: 'baz'
+        }, {
+          bar: 'quux',
+          foo: 'spam'
+        }]
+      })
+
+      argv.should.have.property('foo', 'bar')
+      argv.should.have.property('bar', 'baz')
+    })
   })
 
   describe('dot notation', function () {


### PR DESCRIPTION
I wanted to see in what order `configObjects` were applied, so I wrote a test.

I also added a commit to add `coverage/` to `.gitignore`, since running `npm test` creates it.