### PR TITLE
Revert "fix: make requiresArg work in conjunction with arrays (#136)"

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,12 +180,12 @@ function parse (args, opts) {
     )) {
       key = arg.match(/^--?(.+)/)[1]
 
-      // array format = '--foo a b c'
-      if (checkAllAliases(key, flags.arrays) && args.length > i + 1) {
-        i = eatArray(i, key, args)
       // nargs format = '--foo a b c'
-      } else if (checkAllAliases(key, flags.nargs)) {
+      if (checkAllAliases(key, flags.nargs)) {
         i = eatNargs(i, key, args)
+      // array format = '--foo a b c'
+      } else if (checkAllAliases(key, flags.arrays) && args.length > i + 1) {
+        i = eatArray(i, key, args)
       } else {
         next = args[i + 1]
 

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1774,17 +1774,6 @@ describe('yargs-parser', function () {
 
       result.foo.should.eql('a')
     })
-
-    it('should be ignored if input is an array', function () {
-      var result = parser(['--foo', 'a', 'b'], {
-        array: 'foo',
-        narg: {
-          foo: 1
-        }
-      })
-
-      result.foo.should.eql(['a', 'b'])
-    })
   })
 
   describe('env vars', function () {


### PR DESCRIPTION
This reverts commit 77ae1d4e1c2590eeca025952671fff935ab7e884.

Prior to this commit, those wishing to require that an `array`-type option has a nonzero amount of arguments could use the `check()` function for validation.

The commit removed the ability to use `nargs` in conjunction with `array`-type options.

After this commit, those wishing to limit the number of values an `array`-type option accepts have no viable workaround.  This *also* has the implication that such an option cannot be used prior to a positional option, because it's ambiguous:

```bash
# usage: script [--foo n1 n2] <stuff>
$ script --foo bar baz quux
# `quux` should be `stuff`, but because `foo` is an array, it eats up `quux`.
```

**UPDATE**: Previous to #136, the above example was still an issue, but `nargs(1)` or `requireArg()` was a viable workaround; it no longer is.