### PR TITLE
feat: default value is now used if no right-hand value provided for numbers/strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ function parse (args, opts) {
           setArg(key, next)
           i++
         } else {
-          setArg(key, defaultForType(guessType(key, flags)))
+          setArg(key, defaultValue(key))
         }
       }
 
@@ -220,7 +220,7 @@ function parse (args, opts) {
         setArg(key, next)
         i++
       } else {
-        setArg(key, defaultForType(guessType(key, flags)))
+        setArg(key, defaultValue(key))
       }
     } else if (arg.match(/^-[^-]+/) && !arg.match(negative)) {
       letters = arg.slice(1, -1).split('')
@@ -267,7 +267,7 @@ function parse (args, opts) {
           broken = true
           break
         } else {
-          setArg(letters[j], defaultForType(guessType(letters[j], flags)))
+          setArg(letters[j], defaultValue(letters[j]))
         }
       }
 
@@ -293,7 +293,7 @@ function parse (args, opts) {
             setArg(key, next)
             i++
           } else {
-            setArg(key, defaultForType(guessType(key, flags)))
+            setArg(key, defaultValue(key))
           }
         }
       }
@@ -749,6 +749,18 @@ function parse (args, opts) {
     })
   }
 
+  // make a best effor to pick a default value
+  // for an option based on name and type.
+  function defaultValue (key) {
+    if (!checkAllAliases(key, flags.bools) &&
+        !checkAllAliases(key, flags.counts) &&
+        `${key}` in defaults) {
+      return defaults[key]
+    } else {
+      return defaultForType(guessType(key))
+    }
+  }
+
   // return a default value, given the type of a flag.,
   // e.g., key of type 'string' will default to '', rather than 'true'.
   function defaultForType (type) {
@@ -763,7 +775,7 @@ function parse (args, opts) {
   }
 
   // given a flag, enforce a default type.
-  function guessType (key, flags) {
+  function guessType (key) {
     var type = 'boolean'
 
     if (checkAllAliases(key, flags.strings)) type = 'string'

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -255,7 +255,7 @@ describe('yargs-parser', function () {
   })
 
   // Fixes: https://github.com/bcoe/yargs/issues/68
-  it('should parse flag arguments with no right-hand-value as strings, if defined as strings', function () {
+  it('should parse flag arguments with no right-hand value as strings, if defined as strings', function () {
     var s = parser([ '-s' ], {
       string: ['s']
     }).s
@@ -2822,5 +2822,27 @@ describe('yargs-parser', function () {
       args.foo.should.equal('-hello world')
       args.bar.should.equal('--goodnight moon')
     })
+  })
+
+  // see: https://github.com/yargs/yargs-parser/issues/144
+  it('number/string types should use default when no right-hand value', () => {
+    let argv = parser([ '--foo' ], {
+      number: ['foo'],
+      default: {
+        foo: 99
+      }
+    })
+    argv.foo.should.equal(99)
+
+    argv = parser([ '-b' ], {
+      alias: {
+        bar: 'b'
+      },
+      string: ['bar'],
+      default: {
+        bar: 'hello'
+      }
+    })
+    argv.bar.should.equal('hello')
   })
 })


### PR DESCRIPTION
If default values are provided for an option, they will now be used if a flag is provided with no right-hand value.

fixes: #144 

BREAKING CHANGE: a flag with no right-hand value no longer populates defaulted options with undefined.