### PR TITLE
Fix type "array" with "duplicate-arguments-array"

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ a configuration file.
 * default: `true`
 * key: `duplicate-arguments-array`
 
-Should arguments be coerced into an array when duplicated:
+Should arguments be coerced into an array when duplicated? This option has no effect on `opts.array`.
 
 ```sh
 node example.js -x 1 -x 2

--- a/index.js
+++ b/index.js
@@ -497,13 +497,13 @@ function parse (args, opts) {
   }
 
   function maybeCoerceNumber (key, value) {
+    if (Array.isArray(value)) return value
+
     if (!checkAllAliases(key, flags.strings) && !checkAllAliases(key, flags.coercions)) {
       const shouldCoerceNumber = isNumber(value) && configuration['parse-numbers'] && (
         Number.isSafeInteger(Math.floor(value))
       )
-      if (shouldCoerceNumber || (!isUndefined(value) && checkAllAliases(key, flags.numbers))) {
-        value = Array.isArray(value) ? [Number(value)] : Number(value)
-      }
+      if (shouldCoerceNumber || (!isUndefined(value) && checkAllAliases(key, flags.numbers))) value = Number(value)
     }
     return value
   }

--- a/index.js
+++ b/index.js
@@ -501,7 +501,9 @@ function parse (args, opts) {
       const shouldCoerceNumber = isNumber(value) && configuration['parse-numbers'] && (
         Number.isSafeInteger(Math.floor(value))
       )
-      if (shouldCoerceNumber || (!isUndefined(value) && checkAllAliases(key, flags.numbers))) value = Number(value)
+      if (shouldCoerceNumber || (!isUndefined(value) && checkAllAliases(key, flags.numbers))) {
+        value = Array.isArray(value) ? [Number(value)] : Number(value)
+      }
     }
     return value
   }

--- a/index.js
+++ b/index.js
@@ -686,6 +686,11 @@ function parse (args, opts) {
     var isValueArray = Array.isArray(value)
     var duplicate = configuration['duplicate-arguments-array']
 
+    // array has higher priority than duplicate
+    if (!duplicate && isTypeArray) {
+      duplicate = true
+    }
+
     // nargs has higher priority than duplicate
     if (!duplicate && checkAllAliases(key, flags.nargs)) {
       duplicate = true

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2200,25 +2200,33 @@ describe('yargs-parser', function () {
 
         parsed['x'].should.equal('b')
       })
-      it('array[string]: keeps only last argument', function () {
-        var parsed = parser('-x a -x b', {
-          array: [{ key: 'x', string: true }],
+      it('array[string]: keeps all arguments - ignores configuration', function () {
+        var parsed = parser('-x a -x b -y c', {
+          array: [
+            { key: 'x', string: true },
+            { key: 'y', string: true }
+          ],
           configuration: {
             'duplicate-arguments-array': false
           }
         })
 
-        parsed['x'].should.equal('b')
+        parsed['x'].should.deep.equal(['a', 'b'])
+        parsed['y'].should.deep.equal(['c'])
       })
-      it('array[number]: keeps only last argument', function () {
-        var parsed = parser('-x 1 -x 2', {
-          array: [{ key: 'x', number: true }],
+      it('array[number]: keeps all arguments - ignores configuration', function () {
+        var parsed = parser('-x 1 -x 2 -y 3', {
+          array: [
+            { key: 'x', number: true },
+            { key: 'y', number: true }
+          ],
           configuration: {
             'duplicate-arguments-array': false
           }
         })
 
-        parsed['x'].should.equal(2)
+        parsed['x'].should.deep.equal([1, 2])
+        parsed['y'].should.deep.equal([3])
       })
       it('does not interfere with nargs', function () {
         var parsed = parser('-x a b c -x o p q', {
@@ -2327,15 +2335,16 @@ describe('yargs-parser', function () {
             })
             parsed['x'].should.deep.equal([1, 2, 3])
           })
-          it('[-x 1 2 3 -x 2 3 4] => [2, 3, 4]', function () {
-            var parsed = parser('-x 1 2 3 -x 2 3 4', {
-              array: ['x'],
+          it('[-x 1 2 3 -x 2 3 4] => [[1, 2, 3], [2, 3, 4]]', function () {
+            var parsed = parser('-x 1 2 3 -x 2 3 4 -y 7', {
+              array: ['x', 'y'],
               configuration: {
                 'duplicate-arguments-array': false,
                 'flatten-duplicate-arrays': false
               }
             })
-            parsed['x'].should.deep.equal([2, 3, 4])
+            parsed['x'].should.deep.equal([[1, 2, 3], [2, 3, 4]])
+            parsed['y'].should.deep.equal([7])
           })
         })
         describe('type=number', function () {
@@ -2363,15 +2372,16 @@ describe('yargs-parser', function () {
             })
             parsed['x'].should.deep.equal([1, 2, 3])
           })
-          it('[-x 1 2 3 -x 2 3 4] => [2, 3, 4]', function () {
-            var parsed = parser('-x 1 2 3 -x 2 3 4', {
-              array: ['x'],
+          it('[-x 1 2 3 -x 2 3 4] => [1, 2, 3, 2, 3, 4]', function () {
+            var parsed = parser('-x 1 2 3 -x 2 3 4 -y 7', {
+              array: ['x', 'y'],
               configuration: {
                 'duplicate-arguments-array': false,
                 'flatten-duplicate-arrays': true
               }
             })
-            parsed['x'].should.deep.equal([2, 3, 4])
+            parsed['x'].should.deep.equal([1, 2, 3, 2, 3, 4])
+            parsed['y'].should.deep.equal([7])
           })
         })
         describe('type=number', function () {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2191,7 +2191,7 @@ describe('yargs-parser', function () {
 
         parsed['x'].should.deep.equal(['a', 'b'])
       })
-      it('keeps only last argument', function () {
+      it('string: keeps only last argument', function () {
         var parsed = parser('-x a -x b', {
           configuration: {
             'duplicate-arguments-array': false
@@ -2199,6 +2199,26 @@ describe('yargs-parser', function () {
         })
 
         parsed['x'].should.equal('b')
+      })
+      it('array[string]: keeps only last argument', function () {
+        var parsed = parser('-x a -x b', {
+          array: [{ key: 'x', string: true }],
+          configuration: {
+            'duplicate-arguments-array': false
+          }
+        })
+
+        parsed['x'].should.equal('b')
+      })
+      it('array[number]: keeps only last argument', function () {
+        var parsed = parser('-x 1 -x 2', {
+          array: [{ key: 'x', number: true }],
+          configuration: {
+            'duplicate-arguments-array': false
+          }
+        })
+
+        parsed['x'].should.equal(2)
       })
       it('does not interfere with nargs', function () {
         var parsed = parser('-x a b c -x o p q', {
@@ -2405,25 +2425,25 @@ describe('yargs-parser', function () {
       })
       describe('duplicate=true, flatten=false,', function () {
         describe('type=array', function () {
-          it('[-x 1 -x 2 -x 3] => [1, 2, 3]', function () {
+          it('number: [-x 1 -x 2 -x 3] => [[1], [2], [3]]', function () {
             var parsed = parser('-x 1 -x 2 -x 3', {
-              array: ['x'],
+              array: [{ key: 'x', number: true }],
               configuration: {
                 'duplicate-arguments-array': true,
                 'flatten-duplicate-arrays': false
               }
             })
-            parsed['x'].should.deep.equal([1, 2, 3])
+            parsed['x'].should.deep.equal([[1], [2], [3]])
           })
-          it('[-x 1 2 3 -x 2 3 4] => [[1, 2, 3], [ 2, 3, 4]]', function () {
-            var parsed = parser('-x 1 2 3 -x 2 3 4', {
-              array: ['x'],
+          it("string: [-x 1 -x 2 -x 3] => [['1'], ['2'], ['3']]", function () {
+            var parsed = parser('-x 1 -x 2 -x 3', {
+              array: [{ key: 'x', string: true }],
               configuration: {
                 'duplicate-arguments-array': true,
                 'flatten-duplicate-arrays': false
               }
             })
-            parsed['x'].should.deep.equal([[1, 2, 3], [2, 3, 4]])
+            parsed['x'].should.deep.equal([['1'], ['2'], ['3']])
           })
         })
         describe('type=number', function () {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2200,11 +2200,12 @@ describe('yargs-parser', function () {
 
         parsed['x'].should.equal('b')
       })
-      it('array[string]: keeps all arguments - ignores configuration', function () {
-        var parsed = parser('-x a -x b -y c', {
+      it('string[]: keeps all arguments - ignores configuration', function () {
+        var parsed = parser('-x a -x b -y c -z d e -z f g', {
           array: [
             { key: 'x', string: true },
-            { key: 'y', string: true }
+            { key: 'y', string: true },
+            { key: 'z', string: true }
           ],
           configuration: {
             'duplicate-arguments-array': false
@@ -2213,12 +2214,14 @@ describe('yargs-parser', function () {
 
         parsed['x'].should.deep.equal(['a', 'b'])
         parsed['y'].should.deep.equal(['c'])
+        parsed['z'].should.deep.equal(['d', 'e', 'f', 'g'])
       })
-      it('array[number]: keeps all arguments - ignores configuration', function () {
-        var parsed = parser('-x 1 -x 2 -y 3', {
+      it('number[]]: keeps all arguments - ignores configuration', function () {
+        var parsed = parser('-x 1 -x 2 -y 3 -z 4 5 -z 6 7', {
           array: [
             { key: 'x', number: true },
-            { key: 'y', number: true }
+            { key: 'y', number: true },
+            { key: 'z', number: true }
           ],
           configuration: {
             'duplicate-arguments-array': false
@@ -2227,6 +2230,7 @@ describe('yargs-parser', function () {
 
         parsed['x'].should.deep.equal([1, 2])
         parsed['y'].should.deep.equal([3])
+        parsed['z'].should.deep.equal([4, 5, 6, 7])
       })
       it('does not interfere with nargs', function () {
         var parsed = parser('-x a b c -x o p q', {
@@ -2298,14 +2302,14 @@ describe('yargs-parser', function () {
         duplicate=false, flatten=false
           type=array
             [-x 1 2 3]          => [1, 2, 3]
-            [-x 1 2 3 -x 2 3 4] => [2, 3, 4]
+            [-x 1 2 3 -x 2 3 4] => [[1, 2, 3], [2, 3, 4]]
           type=string/number/etc
             [-x 1 -x 2 -x 3]    => 3
 
         duplicate=false, flatten=true
           type=array
             [-x 1 2 3]          => [1, 2, 3]
-            [-x 1 2 3 -x 2 3 4] => [2, 3, 4]
+            [-x 1 2 3 -x 2 3 4] => [1, 2, 3, 2, 3, 4]
           type=string/number/etc
             [-x 1 -x 2 -x 3]    => 3
 
@@ -2435,25 +2439,33 @@ describe('yargs-parser', function () {
       })
       describe('duplicate=true, flatten=false,', function () {
         describe('type=array', function () {
-          it('number: [-x 1 -x 2 -x 3] => [[1], [2], [3]]', function () {
-            var parsed = parser('-x 1 -x 2 -x 3', {
-              array: [{ key: 'x', number: true }],
+          it('number[]: [-x 1 -x 2 -x 3] => [[1], [2], [3]]', function () {
+            var parsed = parser('-x 1 -x 2 -x 3 -y 4 5 -y 6 7', {
+              array: [
+                { key: 'x', number: true },
+                { key: 'y', number: true }
+              ],
               configuration: {
                 'duplicate-arguments-array': true,
                 'flatten-duplicate-arrays': false
               }
             })
             parsed['x'].should.deep.equal([[1], [2], [3]])
+            parsed['y'].should.deep.equal([[4, 5], [6, 7]])
           })
-          it("string: [-x 1 -x 2 -x 3] => [['1'], ['2'], ['3']]", function () {
-            var parsed = parser('-x 1 -x 2 -x 3', {
-              array: [{ key: 'x', string: true }],
+          it("string[]: [-x 1 -x 2 -x 3] => [['1'], ['2'], ['3']]", function () {
+            var parsed = parser('-x 1 -x 2 -x 3 -y 4 5 -y 6 7', {
+              array: [
+                { key: 'x', string: true },
+                { key: 'y', string: true }
+              ],
               configuration: {
                 'duplicate-arguments-array': true,
                 'flatten-duplicate-arrays': false
               }
             })
             parsed['x'].should.deep.equal([['1'], ['2'], ['3']])
+            parsed['y'].should.deep.equal([['4', '5'], ['6', '7']])
           })
         })
         describe('type=number', function () {


### PR DESCRIPTION
### Description

closes #162 

The `array` type does not work consistently with option `duplicate-arguments-array`.
when `duplicate-arguments-array === false`
- `array` of type `string` **does** reduce duplicate arguments
- `array` of type `number` **does not** reduce duplicate arguments
- `array` of type `boolean` **only works** with arguments provided **in pairs**, eg `--foo true`.
A `boolean` without value (`--foo --no-foo`) results in various bugs as empty arrays, lost flags, lost array type and more.

### Description of Change
- `duplicate-arguments-array` has no effect on option type `array` anymore.
even when `duplicate-arguments-array === false`, you are able to specify:
(output depends on `flatten-duplicate-arrays`)
  - `-x 1 -x 2 -x 3`==> `[1, 2, 3]` or `[[1], [2], [3]]`
  - `-x 1 2 -x 4 5`==> `[1, 2, 4, 5]` or `[[1, 2], [4, 5]]`
- option type `number` and `string` work consistently.
- an `array` value is always an `array`, even if just one value is passed.
- `maybeCoerceNumber()`: fix handling of `array`s.
- adapt existing tests, add new tests

**Please note:** the disabling of creating an `array` by `-x a b c` by default will be implemented in another PR.