### PR TITLE
Fix: "duplicate-arguments-array" should not interfere with "option.nargs"

### DIFF
--- a/index.js
+++ b/index.js
@@ -667,6 +667,14 @@ function parse (args, opts) {
     var isValueArray = Array.isArray(value)
     var duplicate = configuration['duplicate-arguments-array']
 
+    // nargs has higher priority than duplicate
+    if (!duplicate && checkAllAliases(key, flags.nargs)) {
+      duplicate = true
+      if ((!isUndefined(o[key]) && flags.nargs[key] === 1) || (Array.isArray(o[key]) && o[key].length === flags.nargs[key])) {
+        o[key] = undefined
+      }
+    }
+
     if (value === increment) {
       o[key] = increment(o[key])
     } else if (Array.isArray(o[key])) {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2189,6 +2189,16 @@ describe('yargs-parser', function () {
 
         parsed['x'].should.equal('b')
       })
+      it('does not interfere with nargs', function () {
+        var parsed = parser('-x a b c -x o p q', {
+          narg: { x: 3 },
+          configuration: {
+            'duplicate-arguments-array': false
+          }
+        })
+
+        parsed['x'].should.deep.equal(['o', 'p', 'q'])
+      })
     })
 
     describe('flatten duplicate arrays', function () {
@@ -2232,7 +2242,6 @@ describe('yargs-parser', function () {
 
         parsed['x'].should.deep.equal(['a', 'b'])
       })
-
       it('flattens duplicate array type, when argument uses dot notation', function () {
         var parsed = parser('-x.foo a -x.foo b', {
           array: ['x.foo'],


### PR DESCRIPTION
### Description

#closes #118 

```js
var args = parse(
    'foo -p x y', {
        narg: { p: 2 },
        configuration: {
            'duplicate-arguments-array': false,
        }
    }
);
console.log(args);         //  { _: [ 'foo' ], p: 'y' }    <== incorrect
```
the correct output should be:
- 'foo -p x y' => { _: [ 'foo' ], p: [ 'x', 'y' ] }
- 'foo -p x y -p a b' => { _: [ 'foo' ], p: [ 'a', 'b' ] }
- 'foo -p x y z -p a b c' => { _: [ 'foo' ], p: [ 'a', 'b', 'c' ] }

### Description of change

- fix `setKey()`: `nargs` has higher priority than `duplicate`
- add one test
