### PR TITLE
Fix: "TypeError: next.match is not a function" with "number" values

### DIFF
--- a/lib/tokenize-arg-string.js
+++ b/lib/tokenize-arg-string.js
@@ -1,6 +1,8 @@
 // take an un-split argv string and tokenize it.
 module.exports = function (argString) {
-  if (Array.isArray(argString)) return argString
+  if (Array.isArray(argString)) {
+    return argString.map(e => typeof e !== 'string' ? e + '' : e)
+  }
 
   argString = argString.trim()
 

--- a/test/tokenize-arg-string.js
+++ b/test/tokenize-arg-string.js
@@ -12,6 +12,12 @@ describe('TokenizeArgString', function () {
     args[1].should.equal('99')
   })
 
+  it('handles unquoted numbers', function () {
+    var args = tokenizeArgString(['--foo', 9])
+    args[0].should.equal('--foo')
+    args[1].should.equal('9')
+  })
+
   it('handles quoted string with no spaces', function () {
     var args = tokenizeArgString("--foo 'hello'")
     args[0].should.equal('--foo')


### PR DESCRIPTION
### Description

closes #166 

`args = parse( ['--p', 2] );` throws a `TypeError`

### Description of change

- extend "lib/tokenize-arg-string.js": convert all values to `string`'s
- add one test