### PR TITLE
feat: Support boolean which do not consume next argument.

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ function parse (args, opts) {
       } else if (checkAllAliases(key, flags.arrays) && args.length > i + 1) {
         i = eatArray(i, key, args)
       } else {
-        next = args[i + 1]
+        next = flags.nargs[key] === 0 ? undefined : args[i + 1]
 
         if (next !== undefined && (!next.match(/^-/) ||
           next.match(negative)) &&

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -194,6 +194,17 @@ describe('yargs-parser', function () {
     parse.should.have.property('_').and.deep.equal(['aaatrueaaa', 'moo', 'aaafalseaaa'])
   })
 
+  it('should not use next value for boolean configured with zero narg', function () {
+    var parse = parser(['--all', 'false'], {
+      boolean: ['all'],
+      narg: {
+        all: 0
+      }
+    })
+    parse.should.have.property('all', true).and.be.a('boolean')
+    parse.should.have.property('_').and.deep.equal(['false'])
+  })
+
   it('should allow defining options as boolean in groups', function () {
     var parse = parser([ '-x', '-z', 'one', 'two', 'three' ], {
       boolean: ['x', 'y', 'z']


### PR DESCRIPTION
This causes boolean arguments to honor an narg setting of zero.

Fixes #170