### PR TITLE
feat: Add `strip-aliased` and `strip-dashed` configuration options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,49 @@ node example.js -a run b -x y
 { _: [ 'run', 'b', '-x', 'y' ], a: true }
 ```
 
+### strip aliased
+
+* default: `false`
+* key: `strip-aliased`
+
+Should aliases be removed before returning results?
+
+_If disabled:_
+
+```sh
+node example.js --test-field 1
+{ _: [], 'test-field': 1, testField: 1, 'test-alias': 1, testAlias: 1 }
+```
+
+_If enabled:_
+
+```sh
+node example.js --test-field 1
+{ _: [], 'test-field': 1, testField: 1 }
+```
+
+### strip dashed
+
+* default: `false`
+* key: `strip-dashed`
+
+Should dashed keys be removed before returning results?  This option has no effect if
+`camel-case-exansion` is disabled.
+
+_If disabled:_
+
+```sh
+node example.js --test-field 1
+{ _: [], 'test-field': 1, testField: 1 }
+```
+
+_If enabled:_
+
+```sh
+node example.js --test-field 1
+{ _: [], testField: 1 }
+```
+
 ## Special Thanks
 
 The yargs project evolves from optimist and minimist. It owes its

--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ function parse (args, opts) {
     'populate--': false,
     'combine-arrays': false,
     'set-placeholder-key': false,
-    'halt-at-non-option': false
+    'halt-at-non-option': false,
+    'strip-aliased': false,
+    'strip-dashed': false
   }, opts.configuration)
   var defaults = opts.default || {}
   var configObjects = opts.configObjects || []
@@ -332,6 +334,23 @@ function parse (args, opts) {
   notFlags.forEach(function (key) {
     argv[notFlagsArgv].push(key)
   })
+
+  if (configuration['camel-case-expansion'] && configuration['strip-dashed']) {
+    Object.keys(argv).filter(key => key !== '--' && key.includes('-')).forEach(key => {
+      delete argv[key]
+    })
+  }
+
+  if (configuration['strip-aliased']) {
+    // XXX Switch to [].concat(...Object.values(aliases)) once node.js 6 is dropped
+    ;[].concat(...Object.keys(aliases).map(k => aliases[k])).forEach(alias => {
+      if (configuration['camel-case-expansion']) {
+        delete argv[alias.split('.').map(prop => camelCase(prop)).join('.')]
+      }
+
+      delete argv[alias]
+    })
+  }
 
   // how many arguments should we consume, based
   // on the nargs option?

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2863,4 +2863,71 @@ describe('yargs-parser', function () {
     })
     argv.bar.should.equal('hello')
   })
+
+  describe('stripping', function () {
+    it('strip-dashed removes expected fields from argv', function () {
+      const argv = parser([ '--test-value', '1' ], {
+        number: ['test-value'],
+        alias: {
+          'test-value': ['alt-test']
+        },
+        configuration: {
+          'strip-dashed': true
+        }
+      })
+      argv.should.deep.equal({
+        _: [],
+        'testValue': 1,
+        'altTest': 1
+      })
+    })
+
+    it('strip-aliased removes expected fields from argv', function () {
+      const argv = parser([ '--test-value', '1' ], {
+        number: ['test-value'],
+        alias: {
+          'test-value': ['alt-test']
+        },
+        configuration: {
+          'strip-aliased': true
+        }
+      })
+      argv.should.deep.equal({
+        _: [],
+        'test-value': 1,
+        'testValue': 1
+      })
+    })
+
+    it('strip-aliased and strip-dashed combined removes expected fields from argv', function () {
+      const argv = parser([ '--test-value', '1' ], {
+        number: ['test-value'],
+        alias: {
+          'test-value': ['alt-test']
+        },
+        configuration: {
+          'strip-aliased': true,
+          'strip-dashed': true
+        }
+      })
+      argv.should.deep.equal({
+        _: [],
+        'testValue': 1
+      })
+    })
+
+    it('ignores strip-dashed if camel-case-expansion is disabled', function () {
+      const argv = parser([ '--test-value', '1' ], {
+        number: ['test-value'],
+        configuration: {
+          'camel-case-expansion': false,
+          'strip-dashed': true
+        }
+      })
+      argv.should.deep.equal({
+        _: [],
+        'test-value': 1
+      })
+    })
+  })
 })


### PR DESCRIPTION
Enabling these options cause redundant keys to be removed from the
results.  This can be useful when printing the results for debugging as
it reduces the amount of information to look at.