### PR TITLE
fix: should populate "_" when "short-option-groups" is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function parse (args, opts) {
 
     // -- seperated by space.
     } else if (arg.match(/^--.+/) || (
-      !configuration['short-option-groups'] && arg.match(/^-.+/)
+      !configuration['short-option-groups'] && arg.match(/^-[^-]+/)
     )) {
       key = arg.match(/^--?(.+)/)[1]
 

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2442,6 +2442,19 @@ describe('yargs-parser', function () {
         result.should.not.have.property('--')
       })
 
+      it('should populate "_" when given config with "short-option-groups" false', function () {
+        var result = parser.detailed([
+          '--', 'foo'
+        ], {
+          configuration: {
+            'short-option-groups': false
+          }
+        })
+        result.argv.should.deep.equal({ '_': ['foo'] })
+        result.argv.should.not.have.property('--')
+        result.newAliases.should.deep.equal({})
+      })
+
       it('should populate the "--" if populate-- is "true"', function () {
         var result = parser([
           '--name=meowmers', 'bare', '-cats', 'woo', 'moxy',


### PR DESCRIPTION
fix: should populate "_" when given config with "short-option-groups" false
issues: https://github.com/yargs/yargs-parser/issues/177