### PR TITLE
Coerce function returns option of type "number" as "string"

### DIFF
--- a/index.js
+++ b/index.js
@@ -497,7 +497,7 @@ function parse (args, opts) {
   }
 
   function maybeCoerceNumber (key, value) {
-    if (!checkAllAliases(key, flags.strings) && !checkAllAliases(key, flags.coercions)) {
+    if (!checkAllAliases(key, flags.strings)) {
       const shouldCoerceNumber = isNumber(value) && configuration['parse-numbers'] && (
         Number.isSafeInteger(Math.floor(value))
       )
@@ -604,7 +604,7 @@ function parse (args, opts) {
         coerce = checkAllAliases(key, flags.coercions)
         if (typeof coerce === 'function') {
           try {
-            var value = coerce(argv[key])
+            var value = maybeCoerceNumber(key, coerce(argv[key]))
             ;([].concat(flags.aliases[key] || [], key)).forEach(ali => {
               applied[ali] = argv[ali] = value
             })

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2147,14 +2147,18 @@ describe('yargs-parser', function () {
       })
 
       it('parses number if option explicitly set to number type', function () {
-        var parsed = parser(['--foo', '5', '--bar', '6'], {
-          number: 'bar',
+        var parsed = parser(['--foo', '5', '--bar', '6', '--baz', '7'], {
+          number: ['bar', 'baz'],
+          coerce: {
+            'baz': val => val
+          },
           configuration: {
             'parse-numbers': false
           }
         })
         expect(parsed['foo']).to.equal('5')
         expect(parsed['bar']).to.equal(6)
+        expect(parsed['baz']).to.equal(7)
       })
     })
 


### PR DESCRIPTION
### Description

closes #176 

### Description of Change

- `applyCoercions()`: the return value of the coerce function is now checked by calling `maybeCoerceNumber()`, wether it should be converted to type number.
- `maybeCoerceNumber()`: currently return values of coerce functions are not converted to type number.
I deleted this restriction <== **THIS HAS TO BE CONFIRMED**
- extend one existing test
 
