### PR TITLE
Fix "boolean" flag with "duplicate-arguments-array"

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,6 @@ function parse (args, opts) {
     counts: {},
     normalize: {},
     configs: {},
-    defaulted: {},
     nargs: {},
     coercions: {},
     keys: []
@@ -550,7 +549,7 @@ function parse (args, opts) {
       } else {
         // setting arguments via CLI takes precedence over
         // values within the config file.
-        if (!hasKey(argv, fullKey.split('.')) || (flags.defaulted[fullKey]) || (flags.arrays[fullKey] && configuration['combine-arrays'])) {
+        if (!hasKey(argv, fullKey.split('.')) || (flags.arrays[fullKey] && configuration['combine-arrays'])) {
           setArg(fullKey, value)
         }
       }
@@ -579,7 +578,7 @@ function parse (args, opts) {
           return camelCase(key)
         })
 
-        if (((configOnly && flags.configs[keys.join('.')]) || !configOnly) && (!hasKey(argv, keys) || flags.defaulted[keys.join('.')])) {
+        if (((configOnly && flags.configs[keys.join('.')]) || !configOnly) && !hasKey(argv, keys)) {
           setArg(keys.join('.'), process.env[envVar])
         }
       }

--- a/index.js
+++ b/index.js
@@ -132,14 +132,6 @@ function parse (args, opts) {
   })
 
   var argv = { _: [] }
-
-  Object.keys(flags.bools).forEach(function (key) {
-    if (Object.prototype.hasOwnProperty.call(defaults, key)) {
-      setArg(key, defaults[key])
-      setDefaulted(key)
-    }
-  })
-
   var notFlags = []
 
   for (var i = 0; i < args.length; i++) {
@@ -406,8 +398,6 @@ function parse (args, opts) {
   }
 
   function setArg (key, val) {
-    unsetDefaulted(key)
-
     if (/-/.test(key) && configuration['camel-case-expansion']) {
       var alias = key.split('.').map(function (prop) {
         return camelCase(prop)
@@ -704,7 +694,7 @@ function parse (args, opts) {
       }
     } else if (o[key] === undefined && isTypeArray) {
       o[key] = isValueArray ? value : [value]
-    } else if (duplicate && !(o[key] === undefined || checkAllAliases(key, flags.bools) || checkAllAliases(keys.join('.'), flags.bools) || checkAllAliases(key, flags.counts))) {
+    } else if (duplicate && !(o[key] === undefined || checkAllAliases(key, flags.counts))) {
       o[key] = [ o[key], value ]
     } else {
       o[key] = value
@@ -760,18 +750,6 @@ function parse (args, opts) {
     })
 
     return isSet
-  }
-
-  function setDefaulted (key) {
-    [].concat(flags.aliases[key] || [], key).forEach(function (k) {
-      flags.defaulted[k] = true
-    })
-  }
-
-  function unsetDefaulted (key) {
-    [].concat(flags.aliases[key] || [], key).forEach(function (k) {
-      delete flags.defaulted[k]
-    })
   }
 
   // make a best effor to pick a default value

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1108,7 +1108,7 @@ describe('yargs-parser', function () {
         })
       })
 
-      describe('with implied false default', function () {
+      describe('without any default value', function () {
         var opts = null
 
         beforeEach(function () {
@@ -1125,8 +1125,8 @@ describe('yargs-parser', function () {
           parser(['--no-flag'], opts).flag.should.be.false // eslint-disable-line
         })
 
-        it('should set false if no flag in arg', function () {
-          expect(parser([], opts).flag).to.be.undefined // eslint-disable-line
+        it('should not add property if no flag in arg', function () {
+          parser([''], opts).should.not.have.property('flag')
         })
       })
 
@@ -2334,6 +2334,18 @@ describe('yargs-parser', function () {
             parsed['x'].should.deep.equal(3)
           })
         })
+        describe('type=boolean', function () {
+          it('[-x true -x true -x false] => false', function () {
+            var parsed = parser('-x true -x true -x false', {
+              boolean: ['x'],
+              configuration: {
+                'duplicate-arguments-array': false,
+                'flatten-duplicate-arrays': false
+              }
+            })
+            parsed['x'].should.deep.equal(false)
+          })
+        })
       })
       describe('duplicate=false, flatten=true,', function () {
         describe('type=array', function () {
@@ -2368,6 +2380,18 @@ describe('yargs-parser', function () {
               }
             })
             parsed['x'].should.deep.equal(3)
+          })
+        })
+        describe('type=boolean', function () {
+          it('[-x true -x true -x false] => false', function () {
+            var parsed = parser('-x true -x true -x false', {
+              boolean: ['x'],
+              configuration: {
+                'duplicate-arguments-array': false,
+                'flatten-duplicate-arrays': true
+              }
+            })
+            parsed['x'].should.deep.equal(false)
           })
         })
       })
@@ -2406,6 +2430,18 @@ describe('yargs-parser', function () {
             parsed['x'].should.deep.equal([1, 2, 3])
           })
         })
+        describe('type=boolean', function () {
+          it('[-x true -x true -x false] => [true, true, false]', function () {
+            var parsed = parser('-x true -x true -x false', {
+              boolean: ['x'],
+              configuration: {
+                'duplicate-arguments-array': true,
+                'flatten-duplicate-arrays': true
+              }
+            })
+            parsed['x'].should.deep.equal([true, true, false])
+          })
+        })
       })
       describe('duplicate=true, flatten=false,', function () {
         describe('type=array', function () {
@@ -2440,6 +2476,18 @@ describe('yargs-parser', function () {
               }
             })
             parsed['x'].should.deep.equal([1, 2, 3])
+          })
+        })
+        describe('type=boolean', function () {
+          it('[-x true -x true -x false] => [true, true, false]', function () {
+            var parsed = parser('-x true -x true -x false', {
+              boolean: ['x'],
+              configuration: {
+                'duplicate-arguments-array': true,
+                'flatten-duplicate-arrays': false
+              }
+            })
+            parsed['x'].should.deep.equal([true, true, false])
           })
         })
       })


### PR DESCRIPTION
### Description

```js
var args = parse('--file --file', {
  boolean: ['file'],
  configuration: {
    'duplicate-arguments-array': true,
    'flatten-duplicate-arrays': false
  }
})          // { _: [], file: true }
```
The result is incorrect, it should be: `{ _: [], file: [ true, true ] }`

The root problem can be found in an incorrect `boolean` handling of default values and hence a bug fix at the wrong place.

PR #119 shows the `boolean` option behavior when **no default value** is set.
```
var parse = require('yargs-parser');

parse('--flag', {boolean: ['flag']});
// => { _: [], flag: true }

parse('--no-flag', {boolean: ['flag']});
// => { _: [], flag: false }

parse('', {boolean: ['flag']});
// => { _: [] }                     => flag not set similarly to other option type

```
**When a default value is set:**
```
parse('--flag', {boolean: ['flag']});
// => { _: [], flag: true }                 => no default value should be set
                                            => interim result before setKey(): [false, true]

parse('--no-flag', {boolean: ['flag']});
// => { _: [], flag: false }

parse('', {boolean: ['flag']});
// => { _: [], flag: false }           => flag is set to default value
```
In the first case no default must be set since `--flag` as a `boolean` already implicitly carries its value `true`.

### Description of Change

- remove the setting of a default value when a `boolean` is parsed without value. A `boolean` option carries its implicit value `true`.
- `setKey()`: allow `boolean`'s to create `array`'s
