### PR TITLE
Fix: boolean[] -  eatArray() with boolean typed arrays and user defaults

### DIFF
--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1492,6 +1492,14 @@ describe('yargs-parser', function () {
       result.should.have.property('b').and.deep.equal([])
     })
 
+    it('should place default of argument in array, when default provided', function () {
+      var result = parser(['-b'], {
+        array: 'b',
+        default: { 'b': 33 }
+      })
+      result.should.have.property('b').and.deep.equal([33])
+    })
+
     it('should place value of argument in array, when one argument provided', function () {
       var result = parser(['-b', '33'], {
         array: ['b']
@@ -1616,6 +1624,22 @@ describe('yargs-parser', function () {
         array: [{ key: 'x', boolean: true }]
       })
       result.should.have.property('x').that.is.an('array').and.to.deep.equal([true, false])
+    })
+
+    it('should respect type `boolean` without value for arrays', function () {
+      var result = parser(['-x', '-x'], {
+        array: [{ key: 'x', boolean: true }],
+        configuration: { 'flatten-duplicate-arrays': false }
+      })
+      result.x.should.deep.equal([[true], [true]])
+    })
+
+    it('should respect `boolean negation` for arrays', function () {
+      var result = parser(['--no-bool', '--no-bool'], {
+        array: [{ key: 'bool', boolean: true }],
+        configuration: { 'flatten-duplicate-arrays': false }
+      })
+      result.bool.should.deep.equal([[false], [false]])
     })
 
     it('should respect the type `number` option for arrays', function () {


### PR DESCRIPTION
### Description

```js 
var args = parse('--file --file', {
    array: ['file'],
    boolean: ['file'],
    configuration: {
      'duplicate-arguments-array': true,
      'flatten-duplicate-arrays': false
    }
})      // { _: [], file: [ [], [], [] ] }
```
The result is incorrect, it should be: **{ _: [], file: [ [true], [true] ] }**

### Description of Change

- `eatArray()` is called even for flags without arguments. This enables to set:
  - `boolean` with short syntax ('--bool --bool') which carries its implicit value `true`
  - default values given by `opts.default` for all type of options (except `boolean`)
- the fallback default value for all type of options is an empty array `[]`. 
- `eatArray()`: remove the `multipleArrayFlag` logic. The "duplicate array" pattern is already handled within `setKey()` depending on the `flatten-duplicate-arrays` configuration option. `setKey()` remains unchanged.
