### PR TITLE
Fix: number[] - maybeCoerceNumber(): processing of number typed arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -470,7 +470,9 @@ function parse (args, opts) {
       if (typeof val === 'string') val = val === 'true'
     }
 
-    var value = maybeCoerceNumber(key, val)
+    var value = Array.isArray(val)
+      ? val.map(function (v) { return maybeCoerceNumber(key, v) })
+      : maybeCoerceNumber(key, val)
 
     // increment a count given as arg (either no value or value parsed as boolean)
     if (checkAllAliases(key, flags.counts) && (isUndefined(value) || typeof value === 'boolean')) {
@@ -486,7 +488,7 @@ function parse (args, opts) {
   }
 
   function maybeCoerceNumber (key, value) {
-    if (!checkAllAliases(key, flags.strings)) {
+    if (!checkAllAliases(key, flags.strings) && !checkAllAliases(key, flags.bools) && !Array.isArray(value)) {
       const shouldCoerceNumber = isNumber(value) && configuration['parse-numbers'] && (
         Number.isSafeInteger(Math.floor(value))
       )

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2160,6 +2160,19 @@ describe('yargs-parser', function () {
         expect(parsed['bar']).to.equal(6)
         expect(parsed['baz']).to.equal(7)
       })
+
+      it('should coerce elements of number typed arrays to numbers', function () {
+        var parsed = parser(['--foo', '4', '--foo', '5', '2'], {
+          array: ['foo'],
+          configObjects: [{ foo: ['1', '2', '3'] }],
+          configuration: {
+            'combine-arrays': true,
+            'flatten-duplicate-arrays': false
+          }
+        })
+
+        expect(parsed['foo']).to.deep.equal([[4], [5, 2], [1, 2, 3]])
+      })
     })
 
     describe('boolean negation', function () {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2445,7 +2445,7 @@ describe('yargs-parser', function () {
       })
       describe('duplicate=true, flatten=false,', function () {
         describe('type=array', function () {
-          it('[-x 1 -x 2 -x 3] => [1, 2, 3]', function () {
+          it('[-x 1 -x 2 -x 3] => [[1], [2], [3]]', function () {
             var parsed = parser('-x 1 -x 2 -x 3', {
               array: ['x'],
               configuration: {
@@ -2453,7 +2453,7 @@ describe('yargs-parser', function () {
                 'flatten-duplicate-arrays': false
               }
             })
-            parsed['x'].should.deep.equal([1, 2, 3])
+            parsed['x'].should.deep.equal([[1], [2], [3]])
           })
           it('[-x 1 2 3 -x 2 3 4] => [[1, 2, 3], [ 2, 3, 4]]', function () {
             var parsed = parser('-x 1 2 3 -x 2 3 4', {


### PR DESCRIPTION
```js
var args = parse(['--file', 'one', '--nr', '5', '2', '--nr', '4'], {
  array: [{ key: 'nr', number: true }],
  configObjects: [{nr: ['1','2','3']}],
  configuration: {
    'combine-arrays': true,
    'flatten-duplicate-arrays': false
  }
})     // { _: [], file: 'one', nr: [ NaN, 4, NaN ] }
```
The result is incorrect, it should be: { _: [], file: 'one', nr: [ [ 5, 2 ], [ 4 ], [ 1, 2, 3 ] ] }
