### PR TITLE
Fix: eatNargs() for 'opt.narg === 0' and boolean typed options

### DIFF
--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -194,15 +194,17 @@ describe('yargs-parser', function () {
     parse.should.have.property('_').and.deep.equal(['aaatrueaaa', 'moo', 'aaafalseaaa'])
   })
 
-  it('should not use next value for boolean configured with zero narg', function () {
-    var parse = parser(['--all', 'false'], {
-      boolean: ['all'],
-      narg: {
-        all: 0
-      }
+  it('should not use next value for boolean/number/string configured with zero narg', function () {
+    var parse = parser(['--bool', 'false', '--nr', '7', '--str', 'foo'], {
+      boolean: ['bool'],
+      number: ['nr'],
+      string: ['str'],
+      narg: { bool: 0, nr: 0, str: 0 }
     })
-    parse.should.have.property('all', true).and.be.a('boolean')
-    parse.should.have.property('_').and.deep.equal(['false'])
+    parse.should.have.property('bool', true).and.be.a('boolean')
+    parse.should.have.property('nr', undefined).and.be.a('undefined')
+    parse.should.have.property('str', '').and.be.a('string')
+    parse.should.have.property('_').and.deep.equal(['false', 7, 'foo'])
   })
 
   it('should allow defining options as boolean in groups', function () {


### PR DESCRIPTION
### Description

Currently the parser handles `opts.narg` before `opts.array` and therefore `eatArray()` is not restricted by the `opts.narg` value.

The edge case `opt.narg === 0` is handled in a different way since `checkAllAliases()` returns `false` instead of value `0`. Case `opt.narg === 0` should be handled the same way as `opt.narg > 0 ` to keep the distinction between `opts.narg` and `opts.array` options clear and clean.

### Description of Change

- `checkAllAliases()`: fixes case of `opt.narg === 0` and returns now `0` instead of `false`
- `eatNargs()`: sets now default values in case of `opt.narg === 0`

Note: the default value of a string typed option is currently an empty string (`defaultForType()`).
I would have expected `undefined`.