### PR TITLE
feat!: throw exception if incompatible narg/count or narg/array options are used

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,8 @@ function parse (args, opts) {
     })
   })
 
+  checkConfiguration()
+
   var argv = { _: [] }
   var notFlags = []
 
@@ -872,6 +874,20 @@ function parse (args, opts) {
 
   function isUndefined (num) {
     return num === undefined
+  }
+
+  // check user configuration settings for inconsistencies
+  function checkConfiguration () {
+    // count keys should not be set as array/narg
+    Object.keys(flags.counts).find(key => {
+      if (checkAllAliases(key, flags.arrays)) {
+        error = Error(__('Invalid configuration: %s, opts.count excludes opts.array.', key))
+        return true
+      } else if (checkAllAliases(key, flags.nargs)) {
+        error = Error(__('Invalid configuration: %s, opts.count excludes opts.narg.', key))
+        return true
+      }
+    })
   }
 
   return {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1487,6 +1487,24 @@ describe('yargs-parser', function () {
       ], { count: 'v' })
       parsed.v.should.equal(8)
     })
+
+    it('should add an error if counter is also set as array', function () {
+      var argv = parser.detailed(['--counter', '--counter', '--counter'], {
+        count: ['counter'],
+        array: ['counter']
+      })
+
+      argv.error.message.should.equal('Invalid configuration: counter, opts.count excludes opts.array.')
+    })
+
+    it('should add an error if counter is also set as narg', function () {
+      var argv = parser.detailed(['--counter', 'foo', 'bar'], {
+        count: ['counter'],
+        narg: { 'counter': 2 }
+      })
+
+      argv.error.message.should.equal('Invalid configuration: counter, opts.count excludes opts.narg.')
+    })
   })
 
   describe('array', function () {


### PR DESCRIPTION
#### Array:
```js
var args = parse('-f foo baz -f', {
    array: ['f'],
    count: ['f'],
    configuration: {
      'duplicate-arguments-array': true,
      'flatten-duplicate-arrays': false
    }
})       //  { _: [], f: [ [ [Function: increment], [Function: increment] ], [] ] }
```
The result is incorrect, it should be:  **{ _: [ 'foo', 'baz' ], f: 2}**

#### Narg:
```js
var args = parse('-f foo baz -f', {
  narg: {'f': 1},
  count: ['f']
})     // { _: [ 'baz' ], f: 1 }
```
The result is incorrect, it should be: **{ _: [ 'foo', 'baz' ], f: 2 }**

A configuration `opts.count` plus `opts.array` or `opts.narg` does not make sense. Nevertheless this combination can be set by the user.
- ~~we delete `opts.array` / `opts.narg` settings before parsing~~
- we populate `error` with an error object (but don't throw one)
