### PR TITLE
Update index.js for option noProcessValue

### DIFF
--- a/index.js
+++ b/index.js
@@ -408,10 +408,10 @@ function parse (args, opts) {
       addNewAlias(key, alias)
     }
 
-    //var value = processValue(key, val)
+    // allow bypassing of processValue with configuration property
     var value = val
-    if (configuration.noProcessValue===undefined || !configuration.noProcessValue){
-      value =processValue(key, val)    
+    if (configuration['no-process-value'] === undefined || !configuration['no-process-value']) {
+      value = processValue(key, val)
     }
 
     var splitKey = key.split('.')

--- a/index.js
+++ b/index.js
@@ -410,9 +410,9 @@ function parse (args, opts) {
 
     //var value = processValue(key, val)
     var value = val
-    if (configuration.noProcessValue===undefined
-      || !configuration.noProcessValue)
+    if (configuration.noProcessValue===undefined || !configuration.noProcessValue){
       value =processValue(key, val)    
+    }
 
     var splitKey = key.split('.')
     setKey(argv, splitKey, value)

--- a/index.js
+++ b/index.js
@@ -408,7 +408,11 @@ function parse (args, opts) {
       addNewAlias(key, alias)
     }
 
-    var value = processValue(key, val)
+    //var value = processValue(key, val)
+    var value = val
+    if (configuration.noProcessValue===undefined
+      || !configuration.noProcessValue)
+      value =processValue(key, val)    
 
     var splitKey = key.split('.')
     setKey(argv, splitKey, value)


### PR DESCRIPTION
Sometimes a command line value not processed by `processValue` is required.
E.g., cannot distinguish between `value` and `"value"` but they could both be valid and carry different meanings for the application.
Initially hoped to modify yargs-parser and yargs so that both values (processed and unprocessed) could be recovered, but the singleton design and interface increase the workload by a large factor compared to this simple edit.

Top level usage example:
```
const argv = yargs
    .command('pp', 'perform reversible pre proc on file', {
        blah blah blah
    })
    .help()
    .alias('help', 'h')
    .parserConfiguration({noProcessValue:true})
    .argv
```
Then the values in argv are raw, e.g., they are as found in process.argv and don't have some quotes elided.

It would be nice to have both raw and processed, either in one call or sequential calls, but attempts to realize that ran into dead ends.  But that's another story.