### PR TITLE
Fix: setConfigObject() with array typed options and alias/camel-case

### DIFF
--- a/index.js
+++ b/index.js
@@ -555,7 +555,7 @@ function parse (args, opts) {
       } else {
         // setting arguments via CLI takes precedence over
         // values within the config file.
-        if (!hasKey(argv, fullKey.split('.')) || (flags.arrays[fullKey] && configuration['combine-arrays'])) {
+        if (!hasKey(argv, fullKey.split('.')) || (checkAllAliases(fullKey, flags.arrays) && configuration['combine-arrays'])) {
           setArg(fullKey, value)
         }
       }

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -774,6 +774,21 @@ describe('yargs-parser', function () {
       argv.should.have.property('foo', 'bar')
       argv.should.have.property('bar', 'baz')
     })
+
+    it('should combine array typed options with alias and camel-case', function () {
+      var argv = parser(['--camEl', 'foo', '--camEl', 'bar', '-a', 'red'], {
+        array: ['cam-el', 'apple'],
+        alias: { apple: 'a' },
+        configObjects: [{ camEl: 'baz' }, { a: 'sweet' }],
+        configuration: {
+          'combine-arrays': true,
+          'camel-case-expansion': true
+        }
+      })
+
+      argv['cam-el'].should.deep.equal(['foo', 'bar', 'baz'])
+      argv.apple.should.deep.equal(['red', 'sweet'])
+    })
   })
 
   describe('dot notation', function () {


### PR DESCRIPTION
### Description

`setConfigObject()` does not recognise aliases and camel-cased flags when testing for array type.

closes #196 