### PR TITLE
Fix: array option with array default value

### DIFF
--- a/index.js
+++ b/index.js
@@ -388,7 +388,8 @@ function parse (args, opts) {
       // for keys without value ==> argsToSet remains an empty []
       // set user default value, if available
       if (defaults.hasOwnProperty(key)) {
-        argsToSet.push(defaults[key])
+        let defVal = defaults[key]
+        argsToSet = Array.isArray(defVal) ? defVal : [defVal]
       }
     } else {
       for (var ii = i + 1; ii < args.length; ii++) {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1501,18 +1501,21 @@ describe('yargs-parser', function () {
     })
 
     it('should default argument to empty array if no value given', function () {
-      var result = parser(['-b'], {
-        array: 'b'
+      var result = parser(['-b', '--tag'], {
+        array: ['b', 'tag'],
+        default: { 'tag': [] }
       })
-      result.should.have.property('b').and.deep.equal([])
+      result.b.should.deep.equal([])
+      result.tag.should.deep.equal([])
     })
 
     it('should place default of argument in array, when default provided', function () {
-      var result = parser(['-b'], {
-        array: 'b',
-        default: { 'b': 33 }
+      var result = parser(['-b', '--tag'], {
+        array: ['b', 'tag'],
+        default: { 'b': 33, 'tag': ['foo'] }
       })
-      result.should.have.property('b').and.deep.equal([33])
+      result.b.should.deep.equal([33])
+      result.tag.should.deep.equal(['foo'])
     })
 
     it('should place value of argument in array, when one argument provided', function () {


### PR DESCRIPTION
closes #205 

Default values for array typed options can be set now as arrays or as primitive values.