### PR TITLE
fix(unknown-options-as-args): '--' is not an unknown option

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,8 @@ function parse (args, opts) {
     var next
     var value
 
-    if (isUnknownOptionAsArg(arg)) {
+    // any unknown option (except for end-of-options, "--")
+    if (arg !== '--' && isUnknownOptionAsArg(arg)) {
       argv._.push(arg)
     // -- separated by =
     } else if (arg.match(/^--.+=/) || (

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2894,6 +2894,36 @@ describe('yargs-parser', function () {
           k: true
         })
       })
+
+      it('should not identify "--" as an unknown option', function () {
+        const argv = parser('-a -k one -1 -- -b -k two -2', {
+          boolean: ['k'],
+          configuration: {
+            'unknown-options-as-args': true
+          }
+        })
+        argv.should.deep.equal({
+          _: ['-a', 'one', -1, '-b', '-k', 'two', '-2'],
+          k: true
+        })
+      })
+
+      it('should not identify "--" as an unknown option when "populate--" is true', function () {
+        const argv = parser('-a -k one -1 -- -b -k two -2', {
+          boolean: ['k'],
+          configuration: {
+            'populate--': true,
+            'unknown-options-as-args': true
+          }
+        })
+        argv.should.deep.equal({
+          // populate argv._ with everything before the --
+          _: ['-a', 'one', -1],
+          // and argv['--'] with everything after the --
+          '--': ['-b', '-k', 'two', '-2'],
+          k: true
+        })
+      })
     })
   })
 


### PR DESCRIPTION
This fixes an edge case created by @henderea's #181 and #202 when `unknown-options-as-args` and `populate--` are _both_ `true`. I encountered it when attempting to upgrade Lerna from yargs v12 to yargs latest (v14).

In the process of identifying the fix, I realized I probably shouldn't be using `populate--` 🤣 (the new `unknown-options-as-args` is much better for my use-case!)