### PR TITLE
support negative numbers with decimal places

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function parse (args, opts) {
     coercions: {},
     keys: []
   }
-  var negative = /^-[0-9]+(\.[0-9]+)?/
+  var negative = /^-([0-9]+(\.[0-9]+)?|\.[0-9]+)$/
   var negatedBoolean = new RegExp('^--' + configuration['negation-prefix'] + '(.+)')
 
   ;[].concat(opts.array).filter(Boolean).forEach(function (opt) {
@@ -206,7 +206,7 @@ function parse (args, opts) {
       setArg(m[1], m[2])
 
     // dot-notation flag separated by space.
-    } else if (arg.match(/^-.\..+/)) {
+    } else if (arg.match(/^-.\..+/) && !arg.match(negative)) {
       next = args[i + 1]
       key = arg.match(/^-(.\..+)/)[1]
 
@@ -362,7 +362,7 @@ function parse (args, opts) {
     // and terminates when one is observed.
     var available = 0
     for (ii = i + 1; ii < args.length; ii++) {
-      if (!args[ii].match(/^-[^0-9]/) || isUnknownOptionAsArg(args[ii])) available++
+      if (!args[ii].match(/^-[^0-9]/) || args[ii].match(negative) || isUnknownOptionAsArg(args[ii])) available++
       else break
     }
 

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -159,6 +159,21 @@ describe('yargs-parser', function () {
     argv.other.should.deep.equal([-99, -220])
   })
 
+  it('should handle negative (and positive) numbers with decimal places, with or without a leading 0', function () {
+    var argv = parser([
+      '-0.1', '-1.1', '-.5', '-.1', '.1', '.5',
+      '--bounds', '-5.1', '-.1', '.1',
+      '--other', '.9', '-.5'
+    ], {
+      array: 'bounds',
+      narg: { 'other': 2 }
+    })
+
+    argv._.should.deep.equal([-0.1, -1.1, -0.5, -0.1, 0.1, 0.5])
+    argv.bounds.should.deep.equal([-5.1, -0.1, 0.1])
+    argv.other.should.deep.equal([0.9, -0.5])
+  })
+
   it('should set the value of a single short option to the next supplied value, even if the value is empty', function () {
     var parse = parser(['-p', ''])
     parse.should.have.property('p', '')


### PR DESCRIPTION
This pull request fixes some issues with negative numbers containing decimal places.  It also adds support for negative numbers that don't have a leading 0, such as `-.1`.

Fixes yargs/yargs#1204