### PR TITLE
feature: defaulted functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,14 @@ yargs engine.
 * `argv`: an object representing the parsed value of `args`
   * `key/value`: key value pairs for each argument and their aliases.
   * `_`: an array representing the positional arguments.
+  * [optional] `--`:  an array with arguments after the end-of-options flag `--`.
 * `error`: populated with an error object if an exception occurred during parsing.
 * `aliases`: the inferred list of aliases built by combining lists in `opts.alias`.
-* `newAliases`: any new aliases added via camel-case expansion.
-* `configuration`: the configuration loaded from the `yargs` stanza in package.json.
+* `newAliases`: any new aliases added via camel-case expansion:
+  * `boolean`: `{ fooBar: true }`
+* `defaulted`: any new argument created by `opts.default`, no aliases included.
+  * `boolean`: `{ foo: true }`
+* `configuration`: given by default settings and `opts.configuration`.
 
 <a name="configuration"></a>
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ function parse (args, opts) {
   var notFlagsOption = configuration['populate--']
   var notFlagsArgv = notFlagsOption ? '--' : '_'
   var newAliases = {}
+  var defaulted = {}
   // allow a i18n handler to be passed in, default to a fake one (util.format).
   var __ = opts.__ || util.format
   var error = null
@@ -317,7 +318,7 @@ function parse (args, opts) {
   applyEnvVars(argv, false)
   setConfig(argv)
   setConfigObjects()
-  applyDefaultsAndAliases(argv, flags.aliases, defaults)
+  applyDefaultsAndAliases(argv, flags.aliases, defaults, true)
   applyCoercions(argv)
   if (configuration['set-placeholder-key']) setPlaceholderKeys(argv)
 
@@ -627,10 +628,11 @@ function parse (args, opts) {
     return argv
   }
 
-  function applyDefaultsAndAliases (obj, aliases, defaults) {
+  function applyDefaultsAndAliases (obj, aliases, defaults, canLog = false) {
     Object.keys(defaults).forEach(function (key) {
       if (!hasKey(obj, key.split('.'))) {
         setKey(obj, key.split('.'), defaults[key])
+        if (canLog) defaulted[key] = true
 
         ;(aliases[key] || []).forEach(function (x) {
           if (hasKey(obj, x.split('.'))) return
@@ -895,6 +897,7 @@ function parse (args, opts) {
     error: error,
     aliases: flags.aliases,
     newAliases: newAliases,
+    defaulted: defaulted,
     configuration: configuration
   }
 }

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1215,6 +1215,32 @@ describe('yargs-parser', function () {
       parse.should.have.property('t', false).and.be.a('boolean')
       parse.should.have.property('_').and.deep.equal(['moo'])
     })
+
+    it('should log defaulted options - not specified by user', function () {
+      var parsed = parser.detailed('', {
+        default: { foo: 'abc', 'bar.prop': 33, baz: 'x' },
+        configObjects: [{ baz: 'xyz' }]
+      })
+      parsed.argv.should.deep.equal({ '_': [], baz: 'xyz', foo: 'abc', bar: { prop: 33 } })
+      parsed.defaulted.should.deep.equal({ foo: true, 'bar.prop': true })
+    })
+
+    it('should not log defaulted options - specified without value', function () {
+      var parsed = parser.detailed('--foo --bar.prop', {
+        default: { foo: 'abc', 'bar.prop': 33 }
+      })
+      parsed.argv.should.deep.equal({ '_': [], foo: 'abc', bar: { prop: 33 } })
+      parsed.defaulted.should.deep.equal({})
+    })
+
+    it('should log defaulted options - no aliases included', function () {
+      var parsed = parser.detailed('', {
+        default: { kaa: 'abc' },
+        alias: { foo: 'kaa' }
+      })
+      parsed.argv.should.deep.equal({ '_': [], kaa: 'abc', foo: 'abc' })
+      parsed.defaulted.should.deep.equal({ kaa: true })
+    })
   })
 
   describe('camelCase', function () {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1216,30 +1216,41 @@ describe('yargs-parser', function () {
       parse.should.have.property('_').and.deep.equal(['moo'])
     })
 
-    it('should log defaulted options - not specified by user', function () {
-      var parsed = parser.detailed('', {
-        default: { foo: 'abc', 'bar.prop': 33, baz: 'x' },
-        configObjects: [{ baz: 'xyz' }]
+    describe('track defaulted', function () {
+      it('should log defaulted options - not specified by user', function () {
+        var parsed = parser.detailed('', {
+          default: { foo: 'abc', 'bar.prop': 33, baz: 'x' },
+          configObjects: [{ baz: 'xyz' }]
+        })
+        parsed.argv.should.deep.equal({ '_': [], baz: 'xyz', foo: 'abc', bar: { prop: 33 } })
+        parsed.defaulted.should.deep.equal({ foo: true, 'bar.prop': true })
       })
-      parsed.argv.should.deep.equal({ '_': [], baz: 'xyz', foo: 'abc', bar: { prop: 33 } })
-      parsed.defaulted.should.deep.equal({ foo: true, 'bar.prop': true })
-    })
 
-    it('should not log defaulted options - specified without value', function () {
-      var parsed = parser.detailed('--foo --bar.prop', {
-        default: { foo: 'abc', 'bar.prop': 33 }
+      it('should not log defaulted options - specified without value', function () {
+        var parsed = parser.detailed('--foo --bar.prop', {
+          default: { foo: 'abc', 'bar.prop': 33 }
+        })
+        parsed.argv.should.deep.equal({ '_': [], foo: 'abc', bar: { prop: 33 } })
+        parsed.defaulted.should.deep.equal({})
       })
-      parsed.argv.should.deep.equal({ '_': [], foo: 'abc', bar: { prop: 33 } })
-      parsed.defaulted.should.deep.equal({})
-    })
 
-    it('should log defaulted options - no aliases included', function () {
-      var parsed = parser.detailed('', {
-        default: { kaa: 'abc' },
-        alias: { foo: 'kaa' }
+      it('should log defaulted options - no aliases included', function () {
+        var parsed = parser.detailed('', {
+          default: { kaa: 'abc' },
+          alias: { foo: 'kaa' }
+        })
+        parsed.argv.should.deep.equal({ '_': [], kaa: 'abc', foo: 'abc' })
+        parsed.defaulted.should.deep.equal({ kaa: true })
       })
-      parsed.argv.should.deep.equal({ '_': [], kaa: 'abc', foo: 'abc' })
-      parsed.defaulted.should.deep.equal({ kaa: true })
+
+      it('setting an alias excludes associated key from defaulted', function () {
+        var parsed = parser.detailed('--foo abc', {
+          default: { kaa: 'abc' },
+          alias: { foo: 'kaa' }
+        })
+        parsed.argv.should.deep.equal({ '_': [], kaa: 'abc', foo: 'abc' })
+        parsed.defaulted.should.deep.equal({})
+      })
     })
   })
 


### PR DESCRIPTION
closes #203 

`Parse.detailed()` returns an additional object `defaulted` which contains any new argument created by `opts.default`. This argument has not been specified by the user.

` defaulted`: `{ foo: true }`

` defaulted` does not include:
- defaulted aliases
- an option specified by the user on CLI/config/configObjects but without value