### PR TITLE
Feature: pre-parse string of arguments to argv

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ console.log(argv)
 { _: [], foo: 99, bar: 33 }
 ```
 
+Pre-parse a complex string with escaped metacharacters before passing to `yargs-parser`:
+```js
+const parse = require('yargs-parser')
+let argv = parse.toArgv(String.raw`--foo "hello world" "testing \" \"quotes\""`)
+let args = parse(argv, { array: ['foo'] })
+console.log(args)
+```
+
+```sh
+{ _: [], foo: [ 'hello world', 'testing " "quotes"' ] }
+```
+
 Convert an array of mixed types before passing to `yargs-parser`:
 
 ```js
@@ -124,7 +136,7 @@ var parsed = parser(['--no-dice'], {
 })
 ```
 
-### short option groups
+#### short option groups
 
 * default: `true`.
 * key: `short-option-groups`.
@@ -143,7 +155,7 @@ node example.js -abc
 { _: [], abc: true }
 ```
 
-### camel-case expansion
+#### camel-case expansion
 
 * default: `true`.
 * key: `camel-case-expansion`.
@@ -162,7 +174,7 @@ node example.js --foo-bar
 { _: [], 'foo-bar': true }
 ```
 
-### dot-notation
+#### dot-notation
 
 * default: `true`
 * key: `dot-notation`
@@ -181,7 +193,7 @@ node example.js --foo.bar
 { _: [], "foo.bar": true }
 ```
 
-### parse numbers
+#### parse numbers
 
 * default: `true`
 * key: `parse-numbers`
@@ -200,7 +212,7 @@ node example.js --foo=99.3
 { _: [], foo: "99.3" }
 ```
 
-### boolean negation
+#### boolean negation
 
 * default: `true`
 * key: `boolean-negation`
@@ -219,7 +231,7 @@ node example.js --no-foo
 { _: [], "no-foo": true }
 ```
 
-### combine arrays
+#### combine arrays
 
 * default: `false`
 * key: `combine-arrays`
@@ -227,7 +239,7 @@ node example.js --no-foo
 Should arrays be combined when provided by both command line arguments and
 a configuration file.
 
-### duplicate arguments array
+#### duplicate arguments array
 
 * default: `true`
 * key: `duplicate-arguments-array`
@@ -246,7 +258,7 @@ node example.js -x 1 -x 2
 { _: [], x: 2 }
 ```
 
-### flatten duplicate arrays
+#### flatten duplicate arrays
 
 * default: `true`
 * key: `flatten-duplicate-arrays`
@@ -265,7 +277,7 @@ node example.js -x 1 2 -x 3 4
 { _: [], x: [[1, 2], [3, 4]] }
 ```
 
-### negation prefix
+#### negation prefix
 
 * default: `no-`
 * key: `negation-prefix`
@@ -284,7 +296,7 @@ node example.js --quuxfoo
 { _: [], foo: false }
 ```
 
-### populate --
+#### populate --
 
 * default: `false`.
 * key: `populate--`
@@ -305,7 +317,7 @@ node example.js a -b -- x y
 { _: [ 'a' ], '--': [ 'x', 'y' ], b: true }
 ```
 
-### set placeholder key
+#### set placeholder key
 
 * default: `false`.
 * key: `set-placeholder-key`.
@@ -326,7 +338,7 @@ node example.js -a 1 -c 2
 { _: [], a: 1, b: undefined, c: 2 }
 ```
 
-### halt at non-option
+#### halt at non-option
 
 * default: `false`.
 * key: `halt-at-non-option`.
@@ -347,7 +359,7 @@ node example.js -a run b -x y
 { _: [ 'b', '-x', 'y' ], a: 'run' }
 ```
 
-### strip aliased
+#### strip aliased
 
 * default: `false`
 * key: `strip-aliased`
@@ -368,7 +380,7 @@ node example.js --test-field 1
 { _: [], 'test-field': 1, testField: 1 }
 ```
 
-### strip dashed
+#### strip dashed
 
 * default: `false`
 * key: `strip-dashed`
@@ -390,7 +402,7 @@ node example.js --test-field 1
 { _: [], testField: 1 }
 ```
 
-### unknown options as args
+#### unknown options as args
 
 * default: `false`
 * key: `unknown-options-as-args`
@@ -411,6 +423,20 @@ _If enabled_
 node example.js --unknown-option --known-option 2 --string-option --unknown-option2
 { _: ['--unknown-option'], knownOption: 2, stringOption: '--unknown-option2' }
 ```
+
+### require('yargs-parser').toArgv(argString)
+
+Pre-parses a string of arguments supporting quoting and escaping. Returns an array of tokenized arguments `argv`. Handles arguments the same way as Node launched in Bash builds `process.argv`.slice(2).
+
+**expects:**
+
+* `argString`: a string or `String.raw()`representing options to parse.
+
+**returns:**
+
+* `argv`: an array of strings representing the pre-parsed value of `argString`.
+
+**throws:** `SyntaxError`
 
 ## Special Thanks
 

--- a/index.js
+++ b/index.js
@@ -968,4 +968,11 @@ Parser.detailed = function (args, opts) {
   return parse(args.slice(), opts)
 }
 
+// parse string of arguments to string[] 'argv',
+// as Node in Bash builds 'process.argv'
+Parser.toArgv = function (argString) {
+  const bashParse = require('arrgv')
+  return bashParse(argString)
+}
+
 module.exports = Parser

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "standard-version": "^6.0.0"
   },
   "dependencies": {
+    "arrgv": "^1.0.2",
     "camelcase": "^5.0.0",
     "decamelize": "^1.2.0"
   },

--- a/test/bash-parse-toArgv.js
+++ b/test/bash-parse-toArgv.js
@@ -1,0 +1,77 @@
+/* global describe, it */
+
+const toArgv = require('../').toArgv
+
+require('chai').should()
+
+describe('Parser.toArgv() - bash-parse string of arguments to argv', function () {
+  it('handles trivial string', function () {
+    var args = toArgv('--foo ab cd ef')
+    args.should.deep.equal(['--foo', 'ab', 'cd', 'ef'])
+  })
+
+  it('handles trivial string with additional spaces', function () {
+    var args = toArgv('--foo   ab  cd  ef  ')
+    args.should.deep.equal(['--foo', 'ab', 'cd', 'ef'])
+  })
+
+  it('handles quoted separated string', function () {
+    var args = toArgv('--foo ab "cd ef"')
+    args.should.deep.equal(['--foo', 'ab', 'cd ef'])
+  })
+
+  it('handles escaped delimiter', function () {
+    var args = toArgv(String.raw`--foo ab cd\ ef`)
+    args.should.deep.equal(['--foo', 'ab', 'cd ef'])
+  })
+
+  it('handles escaped special character', function () {
+    var args = toArgv(String.raw`--foo ab\ncd`)
+    args.should.deep.equal(['--foo', 'abncd'])
+  })
+
+  it('handles single quotes within double quotes', function () {
+    var args = toArgv(String.raw`--foo ab "c\'d" ef`)
+    args.should.deep.equal(['--foo', 'ab', "c\\'d", 'ef'])
+  })
+
+  it('handles double quotes within single quotes', function () {
+    var args = toArgv(String.raw`--foo ab '"cd"' ef`)
+    args.should.deep.equal(['--foo', 'ab', '"cd"', 'ef'])
+  })
+
+  it('handles double quoted empty strings', function () {
+    var args = toArgv(String.raw`--foo ab "" cd ""`)
+    args.should.deep.equal(['--foo', 'ab', '', 'cd', ''])
+  })
+
+  it('handles single quoted empty strings', function () {
+    var args = toArgv(String.raw`--foo ab '' cd ''`)
+    args.should.deep.equal(['--foo', 'ab', '', 'cd', ''])
+  })
+
+  it('handles escaped double quotes', function () {
+    var args = toArgv(String.raw`--foo ab \"cd ef\"`)
+    args.should.deep.equal(['--foo', 'ab', '"cd', 'ef"'])
+  })
+
+  it('handles escaped single quotes', function () {
+    var args = toArgv(String.raw`--foo 'a'\''b'`)
+    args.should.deep.equal(['--foo', "a'b"])
+  })
+
+  it('handles quoted string with no spaces', function () {
+    var args = toArgv("--foo 'hello'")
+    args.should.deep.equal(['--foo', 'hello'])
+  })
+
+  it('handles single quoted string with spaces', function () {
+    var args = toArgv("--foo 'hello world' --bar='foo bar'")
+    args.should.deep.equal(['--foo', 'hello world', '--bar=foo bar'])
+  })
+
+  it('handles double quoted string with spaces', function () {
+    var args = toArgv('--foo "hello world" --bar="foo bar"')
+    args.should.deep.equal(['--foo', 'hello world', '--bar=foo bar'])
+  })
+})


### PR DESCRIPTION
### Description

closes #180 

Pre-parse a string of arguments into `argv`, as Node launched in Bash builds `process.argv`.slice(2).
Incl. the handling of quoting and escaped metacharacters.

We add a new method `toArgv()`to `Parser`.

```js
'use strict';
const parser = require('yargs-parser');

let argv = parser.toArgv(String.raw`--foo "bar hello" "testing \" this"`);
console.log(argv);       // [ '--foo', 'bar hello', 'testing " this' ]

let args = parser(argv, {
        array: ['foo']
});
console.log(args);       // { _: [], foo: [ 'bar hello', 'testing " this' ] }
```

Running Node on Bash and calling `parser.toArgv` should result in an identical `argv`: 
```
$ node test.js --foo "bar hello" "testing \" this"
// process.argv.slice(2) === [ '--foo', 'bar hello', 'testing " this' ]
```
```
// let res = parser.toArgv(`--foo "bar hello" "testing \\" this"`)  // ok, works
let res = parser.toArgv(String.raw`--foo "bar hello" "testing \" this"`)
// res === [ '--foo', 'bar hello', 'testing " this' ]
```
