### PR TITLE
Trailing and leading quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -469,13 +469,16 @@ function parse (args, opts) {
   }
 
   function processValue (key, val) {
-    // strings may be quoted, clean this up as we assign values.
-    if (typeof val === 'string' &&
-      (val[0] === "'" || val[0] === '"') &&
-      val[val.length - 1] === val[0]
-    ) {
-      val = val.substring(1, val.length - 1)
+    if (typeof val === 'string' && val.startsWith('\\-')) {
+      val = val.substring(1, val.length)
     }
+    // strings may be quoted, clean this up as we assign values.
+    // if (typeof val === 'string' &&
+    //   (val[0] === "'" || val[0] === '"') &&
+    //   val[val.length - 1] === val[0]
+    // ) {
+    //   val = val.substring(1, val.length - 1)
+    // }
 
     // handle parsing boolean arguments --foo=true --bar false.
     if (checkAllAliases(key, flags.bools) || checkAllAliases(key, flags.counts)) {

--- a/lib/tokenize-arg-string.js
+++ b/lib/tokenize-arg-string.js
@@ -27,9 +27,12 @@ module.exports = function (argString) {
     // don't split the string if we're in matching
     // opening or closing single and double quotes.
     if (c === opening) {
+      if (!args[i]) args[i] = ''
       opening = null
+      continue
     } else if ((c === "'" || c === '"') && !opening) {
       opening = c
+      continue
     }
 
     if (!args[i]) args[i] = ''

--- a/test/tokenize-arg-string.js
+++ b/test/tokenize-arg-string.js
@@ -21,42 +21,43 @@ describe('TokenizeArgString', function () {
   it('handles quoted string with no spaces', function () {
     var args = tokenizeArgString("--foo 'hello'")
     args[0].should.equal('--foo')
-    args[1].should.equal("'hello'")
+    args[1].should.equal('hello')
   })
 
   it('handles single quoted string with spaces', function () {
     var args = tokenizeArgString("--foo 'hello world' --bar='foo bar'")
     args[0].should.equal('--foo')
-    args[1].should.equal("'hello world'")
-    args[2].should.equal("--bar='foo bar'")
+    args[1].should.equal('hello world')
+    args[2].should.equal('--bar=foo bar')
   })
 
   it('handles double quoted string with spaces', function () {
     var args = tokenizeArgString('--foo "hello world" --bar="foo bar"')
     args[0].should.equal('--foo')
-    args[1].should.equal('"hello world"')
-    args[2].should.equal('--bar="foo bar"')
+    args[1].should.equal('hello world')
+    args[2].should.equal('--bar=foo bar')
   })
 
   it('handles single quoted empty string', function () {
     var args = tokenizeArgString('--foo \'\' --bar=\'\'')
+    console.log(args)
     args[0].should.equal('--foo')
-    args[1].should.equal("''")
-    args[2].should.equal("--bar=''")
+    args[1].should.equal('')
+    args[2].should.equal('--bar=')
   })
 
   it('handles double quoted empty string', function () {
     var args = tokenizeArgString('--foo "" --bar=""')
     args[0].should.equal('--foo')
-    args[1].should.equal('""')
-    args[2].should.equal('--bar=""')
+    args[1].should.equal('')
+    args[2].should.equal('--bar=')
   })
 
   it('handles quoted string with embedded quotes', function () {
     var args = tokenizeArgString('--foo "hello \'world\'" --bar=\'foo "bar"\'')
     args[0].should.equal('--foo')
-    args[1].should.equal('"hello \'world\'"')
-    args[2].should.equal('--bar=\'foo "bar"\'')
+    args[1].should.equal('hello \'world\'')
+    args[2].should.equal('--bar=foo "bar"')
   })
 
   // https://github.com/yargs/yargs-parser/pull/100
@@ -65,6 +66,6 @@ describe('TokenizeArgString', function () {
     var args = tokenizeArgString('  foo  bar  "foo  bar"  ')
     args[0].should.equal('foo')
     expect(args[1]).equal('bar')
-    expect(args[2]).equal('"foo  bar"')
+    expect(args[2]).equal('foo  bar')
   })
 })

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -3270,8 +3270,8 @@ describe('yargs-parser', function () {
       args.foo.should.equal('hello world')
       args.bar.should.equal('goodnight\'moon')
       const args2 = parser(['--foo', '"hello world"', '--bar="goodnight\'moon"'])
-      args2.foo.should.equal('hello world')
-      args2.bar.should.equal('goodnight\'moon')
+      args2.foo.should.equal('"hello world"')
+      args2.bar.should.equal('"goodnight\'moon"')
     })
 
     it('handles single quoted strings', function () {
@@ -3279,14 +3279,17 @@ describe('yargs-parser', function () {
       args.foo.should.equal('hello world')
       args.bar.should.equal('goodnight"moon')
       const args2 = parser(['--foo', "'hello world'", "--bar='goodnight\"moon'"])
-      args2.foo.should.equal('hello world')
-      args2.bar.should.equal('goodnight"moon')
+      args2.foo.should.equal("'hello world'")
+      args2.bar.should.equal("'goodnight\"moon'")
     })
 
     it('handles strings with dashes', function () {
-      const args = parser('--foo "-hello world" --bar="--goodnight moon"')
+      const args = parser('--foo "\\-hello world" --bar="--goodnight moon"')
       args.foo.should.equal('-hello world')
       args.bar.should.equal('--goodnight moon')
+      const args2 = parser(['--foo', '\\-hello world', '--bar=--goodnight moon'])
+      args2.foo.should.equal('-hello world')
+      args2.bar.should.equal('--goodnight moon')
     })
   })
 


### PR DESCRIPTION
### Description

closes #201 

Currently trailing and leading quotes are removed, this applies to `string` and also to `string[]` input.
```js
> require('yargs-parser')([ '--arg', '"option"' ])
{ _: [], arg: 'option' }
```
One (main?) reason for this: `--arg "--option"`
if user needs `--option` to be handled as value (no option), he wraps the value into quotes which are removed by yargs-parser later on ==> `{ _: [], arg: '--option' }`
Problem: each and every tl-quotes are removed.

### Description of change

This is a delicate topic, so the following is a proposition.

- we distinguish between `string` input and `string[]` input.
  - `string`: there are good reasons to remove tl-quotes, as does eg Bash.
  - `string[]`: we never remove any tl-quotes.
- therefore we move the quote handling from "index.js" to "tokenize-arg-string.js".
- we introduce the escaped dash '\\\\-': 
`[ '--arg', '\\--option' ]` ==> `{ _: [], arg: '--option' }`

BREAKING CHANGE