### PR TITLE
fix: address bugs with "uknown-options-as-args"

### DIFF
--- a/index.js
+++ b/index.js
@@ -762,11 +762,11 @@ function parse (args, opts) {
   }
 
   function hasAnyFlag (key) {
-    // XXX Switch to [].concat(...Object.values(flags)) once node.js 6 is dropped
-    var toCheck = [].concat(...Object.keys(flags).map(k => flags[k]))
+    // XXX Switch to [].concat(Object.values(flags)) once node.js 6 is dropped
+    var toCheck = [].concat(Object.keys(flags).map(k => flags[k]))
 
     return toCheck.some(function (flag) {
-      return flag[key]
+      return Array.isArray(flag) ? flag.includes(key) : flag[key]
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -766,7 +766,7 @@ function parse (args, opts) {
     var toCheck = [].concat(Object.keys(flags).map(k => flags[k]))
 
     return toCheck.some(function (flag) {
-      return Array.isArray(flag) ? flag.includes(key) : flag[key]
+      return Array.isArray(flag) ? flag.includes(key) : flag.hasOwnProperty(key) && flag[key]
     })
   }
 


### PR DESCRIPTION
Closes #226.

Fixes 3 bugs in hasAnyFlag:
1. using `...` inside `concat` flattens all arrays. So if `flags.string` (for example) is an array of string, `toCheck ` does not contain this array of string, but the strings directly. And a few lines below, if `flag` is a string, `flag[repeat]` evaluates to true (as with any method names of String.prototype)
2. once corrected the first bug, if `flag` is now an array, `flag[some]` evaluates to true (Array.prototype...)
3. same thing for the methodes of Object.prototype if `flag` is an object

By the way, yargs-parser crashes when passing a `--toString` option: I thing this kind of bug has to be tracked everywhere in the code (I will open another issue for this).