### PR TITLE
fix!: support keys that collide with object prototypes

### DIFF
--- a/lib/tokenize-arg-string.js
+++ b/lib/tokenize-arg-string.js
@@ -6,13 +6,13 @@ module.exports = function (argString) {
 
   argString = argString.trim()
 
-  var i = 0
-  var prevC = null
-  var c = null
-  var opening = null
-  var args = []
+  let i = 0
+  let prevC = null
+  let c = null
+  let opening = null
+  let args = []
 
-  for (var ii = 0; ii < argString.length; ii++) {
+  for (let ii = 0; ii < argString.length; ii++) {
     prevC = c
     c = argString.charAt(ii)
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "devDependencies": {
-    "c8": "^6.0.0",
+    "c8": "^7.0.1",
     "chai": "^4.2.0",
     "coveralls": "^3.0.2",
     "mocha": "^5.2.0",

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -3,5 +3,6 @@
     "z": 55,
     "foo": "baz",
     "version": "1.0.2",
-    "truthy": true
+    "truthy": true,
+    "toString": "method name"
 }

--- a/test/tokenize-arg-string.js
+++ b/test/tokenize-arg-string.js
@@ -1,52 +1,52 @@
 /* global describe, it */
 
-var tokenizeArgString = require('../lib/tokenize-arg-string')
+const tokenizeArgString = require('../lib/tokenize-arg-string')
 
 require('chai').should()
-var expect = require('chai').expect
+const expect = require('chai').expect
 
 describe('TokenizeArgString', function () {
   it('handles unquoted string', function () {
-    var args = tokenizeArgString('--foo 99')
+    const args = tokenizeArgString('--foo 99')
     args[0].should.equal('--foo')
     args[1].should.equal('99')
   })
 
   it('handles unquoted numbers', function () {
-    var args = tokenizeArgString(['--foo', 9])
+    const args = tokenizeArgString(['--foo', 9])
     args[0].should.equal('--foo')
     args[1].should.equal('9')
   })
 
   it('handles quoted string with no spaces', function () {
-    var args = tokenizeArgString("--foo 'hello'")
+    const args = tokenizeArgString("--foo 'hello'")
     args[0].should.equal('--foo')
     args[1].should.equal("'hello'")
   })
 
   it('handles single quoted string with spaces', function () {
-    var args = tokenizeArgString("--foo 'hello world' --bar='foo bar'")
+    const args = tokenizeArgString("--foo 'hello world' --bar='foo bar'")
     args[0].should.equal('--foo')
     args[1].should.equal("'hello world'")
     args[2].should.equal("--bar='foo bar'")
   })
 
   it('handles double quoted string with spaces', function () {
-    var args = tokenizeArgString('--foo "hello world" --bar="foo bar"')
+    const args = tokenizeArgString('--foo "hello world" --bar="foo bar"')
     args[0].should.equal('--foo')
     args[1].should.equal('"hello world"')
     args[2].should.equal('--bar="foo bar"')
   })
 
   it('handles single quoted empty string', function () {
-    var args = tokenizeArgString('--foo \'\' --bar=\'\'')
+    const args = tokenizeArgString('--foo \'\' --bar=\'\'')
     args[0].should.equal('--foo')
     args[1].should.equal("''")
     args[2].should.equal("--bar=''")
   })
 
   it('handles double quoted empty string', function () {
-    var args = tokenizeArgString('--foo "" --bar=""')
+    const args = tokenizeArgString('--foo "" --bar=""')
     args[0].should.equal('--foo')
     args[1].should.equal('""')
     args[2].should.equal('--bar=""')
@@ -62,7 +62,7 @@ describe('TokenizeArgString', function () {
   // https://github.com/yargs/yargs-parser/pull/100
   // https://github.com/yargs/yargs-parser/pull/106
   it('ignores unneeded spaces', function () {
-    var args = tokenizeArgString('  foo  bar  "foo  bar"  ')
+    const args = tokenizeArgString('  foo  bar  "foo  bar"  ')
     args[0].should.equal('foo')
     expect(args[1]).equal('bar')
     expect(args[2]).equal('"foo  bar"')


### PR DESCRIPTION
BREAKING CHANGE: objects used during parsing are now created with a null
prototype. There may be some scenarios where this change in behavior
leaks externally.

fixes #228 