### PR TITLE
feat!: boolean arguments will not be collected into an implicit array

### DIFF
--- a/index.js
+++ b/index.js
@@ -713,7 +713,11 @@ function parse (args, opts) {
       }
     } else if (o[key] === undefined && isTypeArray) {
       o[key] = isValueArray ? value : [value]
-    } else if (duplicate && !(o[key] === undefined || checkAllAliases(key, flags.counts))) {
+    } else if (duplicate && !(
+      o[key] === undefined ||
+        checkAllAliases(key, flags.counts) ||
+        checkAllAliases(key, flags.bools)
+    )) {
       o[key] = [ o[key], value ]
     } else {
       o[key] = value

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2557,7 +2557,8 @@ describe('yargs-parser', function () {
           })
         })
         describe('type=boolean', function () {
-          it('[-x true -x true -x false] => [true, true, false]', function () {
+          // in the casse of boolean arguments, only the last argument is used:
+          it('[-x true -x true -x false] => false', function () {
             var parsed = parser('-x true -x true -x false', {
               boolean: ['x'],
               configuration: {
@@ -2565,7 +2566,7 @@ describe('yargs-parser', function () {
                 'flatten-duplicate-arrays': true
               }
             })
-            parsed['x'].should.deep.equal([true, true, false])
+            parsed['x'].should.deep.equal(false)
           })
         })
       })
@@ -2605,7 +2606,7 @@ describe('yargs-parser', function () {
           })
         })
         describe('type=boolean', function () {
-          it('[-x true -x true -x false] => [true, true, false]', function () {
+          it('[-x true -x true -x false] => false', function () {
             var parsed = parser('-x true -x true -x false', {
               boolean: ['x'],
               configuration: {
@@ -2613,7 +2614,7 @@ describe('yargs-parser', function () {
                 'flatten-duplicate-arrays': false
               }
             })
-            parsed['x'].should.deep.equal([true, true, false])
+            parsed['x'].should.deep.equal(false)
           })
         })
       })
@@ -3513,5 +3514,13 @@ describe('yargs-parser', function () {
       })
       parse.toString.should.equal(66)
     })
+  })
+
+  // See: https://github.com/facebook/jest/issues/9517
+  it('does not collect arguments configured as booleans into implicit array', () => {
+    var parse = parser(['--infinite', 'true', '--infinite', 'true', '--infinite', 'false'], {
+      boolean: 'infinite'
+    })
+    parse.infinite.should.equal(false)
   })
 })

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -3518,7 +3518,7 @@ describe('yargs-parser', function () {
 
   // See: https://github.com/facebook/jest/issues/9517
   it('does not collect arguments configured as booleans into implicit array', () => {
-    var parse = parser(['--infinite', 'true', '--infinite', 'true', '--infinite', 'false'], {
+    var parse = parser(['--infinite', 'true', '--infinite', 'true', '--no-infinite'], {
       boolean: 'infinite'
     })
     parse.infinite.should.equal(false)


### PR DESCRIPTION
This reverts behavior to match yargs@14. If an argument is configured as a `bool` we will not coerce it into an array.

@SimenB could I get you to try out this branch if you have a moment.

Refs: https://github.com/facebook/jest/issues/9517
BREAKING CHANGE: this reverts parsing behavior of booleans to yargs@14