### PR TITLE
fix: unknown options terminated with digits now handled by unknown-options-as-args

### DIFF
--- a/index.js
+++ b/index.js
@@ -823,7 +823,7 @@ function parse (args, opts) {
     // e.g. '-a-'
     const flagEndingInHyphen = /^-+([^=]+?)-$/
     // e.g. '-abc123'
-    const flagEndingInDigits = /^-+([^=]+?)\d+$/
+    const flagEndingInDigits = /^-+([^=]+?\d+)$/
     // e.g. '-a/usr/local'
     const flagEndingInNonWordCharacters = /^-+([^=]+?)\W+.*$/
     // check the different types of flag styles, including negatedBoolean, a pattern defined near the start of the parse method

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "the mighty option parser used by yargs",
   "main": "index.js",
   "scripts": {
+    "fix": "standard --fix",
     "test": "c8 --reporter=text --reporter=html  mocha test/*.js",
     "posttest": "standard",
-    "coverage": "c8 report --reporter=text-lcov | coveralls",
-    "release": "standard-version"
+    "coverage": "c8 report --reporter=text-lcov | coveralls"
   },
   "repository": {
     "url": "git@github.com:yargs/yargs-parser.git"
@@ -30,8 +30,7 @@
     "chai": "^4.2.0",
     "coveralls": "^3.0.2",
     "mocha": "^5.2.0",
-    "standard": "^12.0.1",
-    "standard-version": "^6.0.0"
+    "standard": "^12.0.1"
   },
   "dependencies": {
     "camelcase": "^5.0.0",

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -3011,6 +3011,22 @@ describe('yargs-parser', function () {
         })
       })
     })
+
+    // See: https://github.com/yargs/yargs-parser/issues/231
+    it('should collect unknown options terminated with digit', function () {
+      const argv = parser('--known-arg=1 --num2', {
+        alias: { 'num': ['n'] },
+        number: ['known-arg'],
+        configuration: {
+          'unknown-options-as-args': true
+        }
+      })
+      argv.should.deep.equal({
+        _: ['--num2'],
+        'known-arg': 1,
+        'knownArg': 1
+      })
+    })
   })
 
   // addresses: https://github.com/yargs/yargs-parser/issues/41


### PR DESCRIPTION
There was a small regex bug that was causing the bug described in #231.

fixes #231 