### PR TITLE
feat: introduce nargs-eats-options config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,13 @@ node example.js -x 1 2 -x 3 4
 { _: [], x: [[1, 2], [3, 4]] }
 ```
 
+### nargs eats options
+
+* default: `false`
+* key: `nargs-eats-options`
+
+Should nargs consume dash options as well as positional arguments.
+
 ### negation prefix
 
 * default: `no-`

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1903,6 +1903,21 @@ describe('yargs-parser', function () {
       result.error.message.should.equal('Not enough arguments following: foo')
     })
 
+    // See: https://github.com/yargs/yargs-parser/issues/232
+    it('should treat flag arguments as satisfying narg requirements, if nargs-eats-options=true', function () {
+      var result = parser.detailed(['--foo', '--bar', '99', '--batman', 'robin'], {
+        narg: {
+          foo: 2
+        },
+        configuration: {
+          'nargs-eats-options': true
+        }
+      })
+
+      result.argv.foo.should.eql(['--bar', 99])
+      result.argv.batman.should.eql('robin')
+    })
+
     it('should not consume more than configured nargs', function () {
       var result = parser(['--foo', 'a', 'b'], {
         narg: {


### PR DESCRIPTION
Setting `nargs-eats-options` to `true` can now be used to put `yargs-parser` back to its pre `v9` behavior.

fixes: #232 
