### PR TITLE
fix: normalized keys were not enumerable

### DIFF
--- a/index.js
+++ b/index.js
@@ -465,6 +465,7 @@ function parse (args, opts) {
       const keys = [key].concat(flags.aliases[key] || [])
       keys.forEach(function (key) {
         Object.defineProperty(argvReturn, key, {
+          enumerable: true,
           get () {
             return val
           },

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -342,6 +342,16 @@ describe('yargs-parser', function () {
       a.should.have.property('s').and.deep.equal(expected)
       a.should.have.property('save').and.deep.equal(expected)
     })
+
+    it('should allow normalized keys to be enumerated', () => {
+      var a = parser(['-s', ['', 'tmp', '..', ''].join(path.sep)], {
+        alias: {
+          s: ['save']
+        },
+        normalize: 's'
+      })
+      Object.keys(a).should.include('s')
+    })
   })
 
   describe('alias', function () {


### PR DESCRIPTION
This was breaking upstream behavior in yargs (and in turn mocha), because the parsed options object is iterated over in yargs and appended to another object:

```bash
mocha init <path>

create a client-side Mocha setup at <path>

Positional Arguments
  path                                                       [string] [required]

Other Options
  --help, -h     Show usage information & exit                         [boolean]
  --version, -V  Show version number & exit                            [boolean]

✖ ERROR: Missing required argument: path
```