### PR TITLE
feat: introduce single-digit boolean aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -304,6 +304,12 @@ function parse (args, opts) {
           }
         }
       }
+    } else if (arg.match(/^-[0-9]$/) &&
+      arg.match(negative) &&
+      checkAllAliases(arg.slice(1), flags.bools)) {
+      // single-digit boolean alias, e.g: xargs -0
+      key = arg.slice(1)
+      setArg(key, defaultValue(key))
     } else if (arg === '--') {
       notFlags = args.slice(i + 1)
       break
@@ -347,7 +353,6 @@ function parse (args, opts) {
   }
 
   if (configuration['strip-aliased']) {
-    // XXX Switch to [].concat(...Object.values(aliases)) once node.js 6 is dropped
     ;[].concat(...Object.keys(aliases).map(k => aliases[k])).forEach(alias => {
       if (configuration['camel-case-expansion']) {
         delete argv[alias.split('.').map(prop => camelCase(prop)).join('.')]

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -438,6 +438,47 @@ describe('yargs-parser', function () {
       argv.should.have.property('zm', 55)
       argv.should.have.property('f', 11)
     })
+
+    it('should set single-digit boolean alias', function () {
+      var argv = parser(['-f', '11', '-0'], {
+        alias: {
+          0: 'print0'
+        },
+        boolean: [
+          'print0'
+        ]
+      })
+      argv.should.have.property('print0', true)
+      argv.should.have.property('f', 11)
+    })
+
+    it('should not set single-digit alias if no alias defined', function () {
+      var argv = parser(['-f', '11', '-0', '-1'])
+      argv.should.have.property('f', 11)
+      argv._.should.deep.equal([-0, -1])
+    })
+
+    it('should not set single-digit boolean alias if no boolean defined', function () {
+      var argv = parser(['-f', '11', '-9'], {
+        alias: {
+          0: 'print0'
+        }
+      })
+      argv.should.have.property('f', 11)
+      argv._.should.deep.equal([-9])
+    })
+
+    it('should be able to negate set single-digit boolean alias', function () {
+      var argv = parser(['--no-9'], {
+        alias: {
+          9: 'max'
+        },
+        boolean: [
+          'max'
+        ]
+      })
+      argv.should.have.property('max', false)
+    })
   })
 
   it('should assign data after forward slash to the option before the slash', function () {


### PR DESCRIPTION
Following up from the discussion from: https://github.com/yargs/yargs/issues/1454 even though there are plenty of valid usecases for single-digit aliases and many well stablished examples, it is still completely unsupported on yargs-parser.

As brought up by @benjie many standard unix tools uses such pattern, after reading his examples and giving it some thought, I ended up classifying them in two groups:

- Single-digit shortcut flags, which behave as booleans modifying behavior within the tool:
  - `xargs -0`
  - `kill -9`
  - `gzip -1`
  - `rsync -6`
- Numeric shortcut params, which behave as actual number configs:
  - `git log -3`
  - `grep -3`

This changeset introduces the support to the first group described, in which single-digits can be used as alias in the context of boolean flags.

/cc @bcoe @mleguen 