### PR TITLE
fix(array, nargs): support -o=--value and --option=--value format

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,8 +239,7 @@ function parse (args, opts) {
 
           if (checkAllAliases(key, flags.arrays)) {
             // array format = '-f=a b c'
-            args.splice(i + 1, 0, value)
-            i = eatArray(i, key, args)
+            i = eatArray(i, key, args, value)
           } else if (checkAllAliases(key, flags.nargs)) {
             // nargs format = '-f=monkey washing cat'
             i = eatNargs(i, key, args, value)

--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ function parse (args, opts) {
       // arrays format = '--f=a b c'
       if (checkAllAliases(m[1], flags.arrays)) {
         i = eatArray(i, m[1], args, m[2])
-      } else if (checkAllAliases(m[1], flags.nargs)) {
+      } else if (checkAllAliases(m[1], flags.nargs) !== false) {
         // nargs format = '--f=monkey washing cat'
         i = eatNargs(i, m[1], args, m[2])
       } else {
@@ -240,7 +240,7 @@ function parse (args, opts) {
           if (checkAllAliases(key, flags.arrays)) {
             // array format = '-f=a b c'
             i = eatArray(i, key, args, value)
-          } else if (checkAllAliases(key, flags.nargs)) {
+          } else if (checkAllAliases(key, flags.nargs) !== false) {
             // nargs format = '-f=monkey washing cat'
             i = eatNargs(i, key, args, value)
           } else {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -3729,6 +3729,18 @@ describe('yargs-parser', function () {
       parse.error.message.should.equal('Not enough arguments following: a')
     })
 
+    it('returns an error if not enough positionals were provided for nargs even with nargs-eats-options', () => {
+      var parse = parser.detailed(['-a', '33', '--cat'], {
+        narg: {
+          a: 3
+        },
+        configuration: {
+          'nargs-eats-options': true
+        }
+      })
+      parse.error.message.should.equal('Not enough arguments following: a')
+    })
+
     it('does not raise error if no arguments are provided for boolean option', () => {
       var parse = parser.detailed(['-a'], {
         array: 'a',

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1753,9 +1753,9 @@ describe('yargs-parser', function () {
         array: ['option']
       })
 
-      Array.isArray(result['option']).should.equal(true)
-      result['option'][0].should.equal('--a')
-      result['option'][1].should.equal('b')
+      Array.isArray(result.option).should.equal(true)
+      result.option[0].should.equal('--a')
+      result.option[1].should.equal('b')
     })
 
     it('should create an array when passing an argument twice with same value', function () {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1748,14 +1748,18 @@ describe('yargs-parser', function () {
       result['1'][1].should.equal('b')
     })
 
-    it('should support array for --foo= format when the value is dashed', function () {
-      var result = parser(['--option=--a', 'b'], {
-        array: ['option']
+    it('should support array for -f= and --bar= format when the value is dashed', function () {
+      var result = parser(['-f=--dog', 'cat', '--bar=--red', 'green'], {
+        array: ['f', 'bar']
       })
 
-      Array.isArray(result.option).should.equal(true)
-      result.option[0].should.equal('--a')
-      result.option[1].should.equal('b')
+      Array.isArray(result.f).should.equal(true)
+      result.f[0].should.equal('--dog')
+      result.f[1].should.equal('cat')
+
+      Array.isArray(result.bar).should.equal(true)
+      result.bar[0].should.equal('--red')
+      result.bar[1].should.equal('green')
     })
 
     it('should create an array when passing an argument twice with same value', function () {

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1931,6 +1931,23 @@ describe('yargs-parser', function () {
       result._[1].should.equal('cat')
     })
 
+    it('should support nargs for -f= and --bar= format arguments with dashed values', function () {
+      var result = parser(['-f=--apple', 'bar', 'blerg', '--bar=-monkey', 'washing', 'cat'], {
+        narg: {
+          f: 2,
+          bar: 2
+        }
+      })
+
+      result.f[0].should.equal('--apple')
+      result.f[1].should.equal('bar')
+      result._[0].should.equal('blerg')
+
+      result.bar[0].should.equal('-monkey')
+      result.bar[1].should.equal('washing')
+      result._[1].should.equal('cat')
+    })
+
     it('should not modify the input args if an = was used', function () {
       var expected = ['-f=apple', 'bar', 'blerg', '--bar=monkey', 'washing', 'cat']
       var args = expected.slice()

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1748,6 +1748,16 @@ describe('yargs-parser', function () {
       result['1'][1].should.equal('b')
     })
 
+    it('should support array for --foo= format when the value is dashed', function () {
+      var result = parser(['--option=--a', 'b'], {
+        array: ['option']
+      })
+
+      Array.isArray(result['option']).should.equal(true)
+      result['option'][0].should.equal('--a')
+      result['option'][1].should.equal('b')
+    })
+
     it('should create an array when passing an argument twice with same value', function () {
       var result = parser(['-x', 'val1', '-x', 'val1'])
       result.should.have.property('x').that.is.an('array').and.to.deep.equal(['val1', 'val1'])

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -1883,6 +1883,24 @@ describe('yargs-parser', function () {
       result.foo[1].should.equal('bar')
     })
 
+    it('should raise an exception if -f== format is used for a key with no expected argument', function () {
+      var argv = parser.detailed('-f=apple', {
+        narg: {
+          f: 0
+        }
+      })
+      argv.error.message.should.equal('Argument unexpected for: f')
+    })
+
+    it('should raise an exception if --bar== format is used for a key with no expected argument', function () {
+      var argv = parser.detailed('--bar=apple', {
+        narg: {
+          bar: 0
+        }
+      })
+      argv.error.message.should.equal('Argument unexpected for: bar')
+    })
+
     it('should raise an exception if there are not enough arguments following key', function () {
       var argv = parser.detailed('--foo apple', {
         narg: {


### PR DESCRIPTION
Fixes #261 

As a side effect, this PR also enforces narg 0 for -o=value and --option=value, with a new "Argument unexpected for: %s" error (was silently ignored up to now).