### PR TITLE
fix(setArg): options using camel-case and dot-notation populated twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -480,7 +480,11 @@ function parse (args, opts) {
         a.shift() // nuke the old key.
         x = x.concat(a)
 
-        setKey(argv, x, value)
+        // populate alias only if is not already an alias of the full key
+        // (already populated above)
+        if (!(flags.aliases[key] || []).includes(x.join('.'))) {
+          setKey(argv, x, value)
+        }
       })
     }
 

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -959,6 +959,20 @@ describe('yargs-parser', function () {
       })
 
       argv.f.bar.should.eql(99)
+      argv.foo.bar.should.eql(99)
+    })
+
+    // see #267
+    it('should populate aliases when dot notation is used on camel-cased option', function () {
+      var argv = parser(['--foo-baz.bar', '99'], {
+        alias: {
+          'foo-baz': ['f']
+        }
+      })
+
+      argv.f.bar.should.eql(99)
+      argv['foo-baz'].bar.should.eql(99)
+      argv.fooBaz.bar.should.eql(99)
     })
 
     it('should populate aliases when nested dot notation is used', function () {


### PR DESCRIPTION
Fix #267 