### PR TITLE
fix: back-porting prototype fixes for *really* old version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "standard-version": "^4.0.0"
   },
   "dependencies": {
-    "camelcase": "^3.0.0"
+    "camelcase": "^3.0.0",
+    "object.assign": "^4.1.0"
   },
   "files": [
     "lib",

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -3,5 +3,14 @@
     "z": 55,
     "foo": "baz",
     "version": "1.0.2",
-    "truthy": true
+    "truthy": true,
+    "toString": "method name",
+    "__proto__": {
+        "aaa": 99
+    },
+    "bar": {
+        "__proto__": {
+            "bbb": 100
+        }
+    }
 }

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -410,6 +410,26 @@ describe('yargs-parser', function () {
   describe('config', function () {
     var jsonPath = path.resolve(__dirname, './fixtures/config.json')
 
+    // Patching for https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381
+    it('should not pollute the prototype', function () {
+      const argv = parser(['--foo', 'bar'], {
+        alias: {
+          z: 'zoom'
+        },
+        default: {
+          settings: jsonPath
+        },
+        config: 'settings'
+      })
+
+      argv.should.have.property('herp', 'derp')
+      argv.should.have.property('zoom', 55)
+      argv.should.have.property('foo').and.deep.equal('bar')
+
+      expect({}.bbb).to.equal(undefined)
+      expect({}.aaa).to.equal(undefined)
+    })
+
     // See: https://github.com/chevex/yargs/issues/12
     it('should load options and values from default config if specified', function () {
       var argv = parser([ '--foo', 'bar' ], {
@@ -2374,5 +2394,13 @@ describe('yargs-parser', function () {
       configObjects: [{'a': ['bin/../a.txt', 'bin/../b.txt']}]
     })
     argv.a.should.deep.equal(['a.txt', 'b.txt'])
+  })
+
+  // Patching for https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381
+  it('should not pollute the prototype', function () {
+    parser(['-f.__proto__.foo', '99', '-x.y.__proto__.bar', '100', '--__proto__', '200'])
+    Object.keys({}.__proto__).length.should.equal(0) // eslint-disable-line
+    expect({}.foo).to.equal(undefined)
+    expect({}.bar).to.equal(undefined)
   })
 })

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2397,7 +2397,7 @@ describe('yargs-parser', function () {
   })
 
   // Patching for https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381
-  it.skip('should not pollute the prototype', function () {
+  it('should not pollute the prototype', function () {
     parser(['-f.__proto__.foo', '99', '-x.y.__proto__.bar', '100', '--__proto__', '200'])
     Object.keys({}.__proto__).length.should.equal(0) // eslint-disable-line
     expect({}.foo).to.equal(undefined)

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -2397,7 +2397,7 @@ describe('yargs-parser', function () {
   })
 
   // Patching for https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381
-  it('should not pollute the prototype', function () {
+  it.skip('should not pollute the prototype', function () {
     parser(['-f.__proto__.foo', '99', '-x.y.__proto__.bar', '100', '--__proto__', '200'])
     Object.keys({}.__proto__).length.should.equal(0) // eslint-disable-line
     expect({}.foo).to.equal(undefined)


### PR DESCRIPTION
GitHub won't let me create a draft against another tag so this diff is going to be really weird.

I'm guessing the best way to work on this would be to branch `v5.0.0` tag into a branch and then PR against that. Once it is merged and released, the branch can be cleaned up since the tag will point to the new version.

Drafting while WIP.