### PR TITLE
fix(deps): update dependency decamelize to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "camelcase": "^5.0.0",
-    "decamelize": "^1.2.0"
+    "decamelize": "^3.2.0"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Update decamelize dependency to get latest TypeScript definition as part of #265.

Package | Type | Update | Change
-------- | ----- | ------- | --------
[decamelize](https://github.com/sindresorhus/decamelize/) | dependencies | major | [`^1.2.0` -> `^3.2.0`](https://github.com/sindresorhus/decamelize/compare/v1.2.0...v3.2.0)