### PR TITLE
build!: drops Node 6. begin following Node.js LTS schedule

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [8, 10, 12, 13]
+        node: [10, 12, 14]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ node example.js --unknown-option --known-option 2 --string-option --unknown-opti
 
 Libraries in this ecosystem make a best effort to track
 [Node.js' release schedule](https://nodejs.org/en/about/releases/). Here's [a
-post on why we think this is valuable](https://medium.com/the-node-js-collection/maintainers-should-consider-following-node-js-release-schedule-ab08ed4de71a).
+post on why we think this is important](https://medium.com/the-node-js-collection/maintainers-should-consider-following-node-js-release-schedule-ab08ed4de71a).
 
 ## Special Thanks
 

--- a/README.md
+++ b/README.md
@@ -439,6 +439,12 @@ node example.js --unknown-option --known-option 2 --string-option --unknown-opti
 { _: ['--unknown-option'], knownOption: 2, stringOption: '--unknown-option2' }
 ```
 
+## Supported Node.js Versions
+
+Libraries in this ecosystem make a best effort to track
+[Node.js' release schedule](https://nodejs.org/en/about/releases/). Here's [a
+post on why we thin this is valuable](https://medium.com/the-node-js-collection/maintainers-should-consider-following-node-js-release-schedule-ab08ed4de71a).
+
 ## Special Thanks
 
 The yargs project evolves from optimist and minimist. It owes its

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ node example.js --unknown-option --known-option 2 --string-option --unknown-opti
 
 Libraries in this ecosystem make a best effort to track
 [Node.js' release schedule](https://nodejs.org/en/about/releases/). Here's [a
-post on why we thin this is valuable](https://medium.com/the-node-js-collection/maintainers-should-consider-following-node-js-release-schedule-ab08ed4de71a).
+post on why we think this is valuable](https://medium.com/the-node-js-collection/maintainers-should-consider-following-node-js-release-schedule-ab08ed4de71a).
 
 ## Special Thanks
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,17 @@ const path = require('path')
 const tokenizeArgString = require('./lib/tokenize-arg-string')
 const util = require('util')
 
+// See https://github.com/yargs/yargs-parser#supported-nodejs-versions for our
+// version support policy. The YARGS_MIN_NODE_VERSION is used for testing only.
+const minNodeVersion = (process && process.env && process.env.YARGS_MIN_NODE_VERSION)
+  ? Number(process.env.YARGS_MIN_NODE_VERSION) : 10
+if (process && process.version) {
+  const major = Number(process.version.match(/v([^.]+)/)[1])
+  if (major < minNodeVersion) {
+    throw Error(`yargs parser supports a minimum Node.js version of ${minNodeVersion}. Read our version support policy: https://github.com/yargs/yargs-parser#supported-nodejs-versions`)
+  }
+}
+
 function parse (args, opts) {
   opts = Object.assign(Object.create(null), opts)
   // allow a string argument to be passed in rather
@@ -626,8 +637,8 @@ function parse (args, opts) {
   }
 
   function applyEnvVars (argv, configOnly) {
+    if (!process) return
     if (typeof envPrefix === 'undefined') return
-
     const prefix = typeof envPrefix === 'string' ? envPrefix : ''
     Object.keys(process.env).forEach(function (envVar) {
       if (prefix === '' || envVar.lastIndexOf(prefix, 0) === 0) {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "index.js"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   }
 }

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -3823,4 +3823,13 @@ describe('yargs-parser', function () {
       }
     })
   })
+
+  it('throws error for unsupported Node.js versions', () => {
+    process.env.YARGS_MIN_NODE_VERSION = '55'
+    delete require.cache[require.resolve('../')]
+    expect(() => {
+      require('../')
+    }).to.throw(/yargs parser supports a minimum Node.js version of 55/)
+    delete process.env.YARGS_MIN_NODE_VERSION
+  })
 })


### PR DESCRIPTION
This skips the EOL Node 8, and moves us to Node 10 as the supported Node.js version for yargs-parser.

_Note: we should complete the TypeScript conversion before we release this major version of the library._

TODO:

- [x] I'd like to add a snippet of code that throws if you're on an older Node.js version.

Refs #272