### PR TITLE
chore(deps): update devDependency eslint to 6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/parser": "^2.25.0",
     "c8": "^7.1.2",
     "chai": "^4.2.0",
-    "eslint": "^7.0.0",
+    "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-node": "^11.0.0",
     "gts": "^2.0.0-alpha.4",


### PR DESCRIPTION
This PR downgrades devDependency eslint from v7.0 to v6.8.0 and resolves the npm install warnings. In #272 I had matched the semver used for yargs dependencies but yargs had prematurely upgraded eslint.

```text
npm WARN @typescript-eslint/eslint-plugin@2.34.0 requires a peer of eslint@^5.0.0 || ^6.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @typescript-eslint/parser@2.34.0 requires a peer of eslint@^5.0.0 || ^6.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN eslint-plugin-react@7.14.3 requires a peer of eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 but none is installed. You must install peer dependencies yourself.
```