### PR TITLE
feat: expose camelCase and decamelize helpers

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -2,6 +2,7 @@
 // specific libraries, such as "path".
 //
 // TODO: figure out reasonable web equivalents for "resolve", "normalize", etc.
+import { camelCase, decamelize } from './build/lib/string-utils.js'
 import { YargsParser } from './build/lib/yargs-parser.js'
 const parser = new YargsParser({
   cwd: () => { return '' },
@@ -18,9 +19,10 @@ const yargsParser = function Parser (args, opts) {
   const result = parser.parse(args.slice(), opts)
   return result.argv
 }
-
 yargsParser.detailed = function (args, opts) {
   return parser.parse(args.slice(), opts)
 }
+yargsParser.camelCase = camelCase
+yargsParser.decamelize = decamelize
 
 export default yargsParser

--- a/deno.ts
+++ b/deno.ts
@@ -3,6 +3,7 @@
 //
 // TODO: find reasonable replacement for require logic.
 import * as path from 'https://deno.land/std/path/mod.ts'
+import { camelCase, decamelize } from './build/lib/string-utils.js'
 import { YargsParser } from './build/lib/yargs-parser.js'
 import { Arguments, ArgsInput, Parser, Options, DetailedArguments } from './build/lib/yargs-parser-types.d.ts'
 
@@ -27,9 +28,10 @@ const yargsParser: Parser = function Parser (args: ArgsInput, opts?: Partial<Opt
   const result = parser.parse(args.slice(), opts)
   return result.argv
 }
-
 yargsParser.detailed = function (args: ArgsInput, opts?: Partial<Options>): DetailedArguments {
   return parser.parse(args.slice(), opts)
 }
+yargsParser.camelCase = camelCase
+yargsParser.decamelize = decamelize
 
 export default yargsParser

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,7 @@ import { format } from 'util'
 import { readFileSync } from 'fs'
 import { normalize, resolve } from 'path'
 import { ArgsInput, Arguments, Parser, Options, DetailedArguments } from './yargs-parser-types.js'
+import { camelCase, decamelize } from './string-utils.js'
 import { YargsParser } from './yargs-parser.js'
 
 // See https://github.com/yargs/yargs-parser#supported-nodejs-versions for our
@@ -46,4 +47,6 @@ const yargsParser: Parser = function Parser (args: ArgsInput, opts?: Partial<Opt
 yargsParser.detailed = function (args: ArgsInput, opts?: Partial<Options>): DetailedArguments {
   return parser.parse(args.slice(), opts)
 }
+yargsParser.camelCase = camelCase
+yargsParser.decamelize = decamelize
 export default yargsParser

--- a/lib/yargs-parser-types.ts
+++ b/lib/yargs-parser-types.ts
@@ -127,6 +127,8 @@ export type OptionsDefault = ValueOf<Pick<Required<Options>, 'default'>>;
 export interface Parser {
   (args: ArgsInput, opts?: Partial<Options>): Arguments;
   detailed(args: ArgsInput, opts?: Partial<Options>): DetailedArguments;
+  camelCase(str: string): string;
+  decamelize(str: string, joinString?: string): string;
 }
 
 export type StringFlag = Dictionary<string[]>;

--- a/test/deno/yargs-test.ts
+++ b/test/deno/yargs-test.ts
@@ -5,6 +5,7 @@ import {
 } from 'https://deno.land/std/testing/asserts.ts'
 import parser from '../../deno.ts'
 
+// Parser:
 Deno.test('parse string', () => {
   const parsed = parser('--foo --bar 99')
   assertEquals(parsed.foo, true)
@@ -43,4 +44,13 @@ Deno.test('should load options and values from default config if specified', () 
   assertEquals(argv.herp, 'derp')
   assertEquals(argv.zoom, 55)
   assertEquals(argv.zoom, 55)
+})
+
+// String utilities:
+Deno.test('convert hyphenated string to camelcase', () => {
+  assertEquals(parser.camelCase('hello-world'), 'helloWorld')
+})
+
+Deno.test('convert camelcase string to hyphenated', () => {
+  assertEquals(parser.decamelize('helloWorld'), 'hello-world')
 })

--- a/test/string-utils.cjs
+++ b/test/string-utils.cjs
@@ -1,0 +1,20 @@
+/* global describe, it */
+
+const { expect } = require('chai')
+const { camelCase, decamelize } = require('../build/index.cjs')
+
+describe('string-utils', function () {
+  describe('camelCase', () => {
+    it('converts string with hypen in middle to camel case', () => {
+      expect(camelCase('hello-world')).to.equal('helloWorld')
+    })
+    it('removes leading hyphens', () => {
+      expect(camelCase('-goodnight-moon')).to.equal('goodnightMoon')
+    })
+  })
+  describe('decamelize', () => {
+    it('adds hyphens back to camelcase string', () => {
+      expect(decamelize('helloWorld')).to.equal('hello-world')
+    })
+  })
+})


### PR DESCRIPTION
Exposes camelCase and decamelize methods, so that they can be used upstream by yargs.