### PR TITLE
feat: adds parse-positional-numbers configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,25 @@ node example.js --foo=99.3
 { _: [], foo: "99.3" }
 ```
 
+### parse positional numbers
+
+* default: `true`
+* key: `parse-positional-numbers`
+
+Should positional keys that look like numbers be treated as such.
+
+```sh
+node example.js 99.3
+{ _: [99] }
+```
+
+_if disabled:_
+
+```sh
+node example.js 99.3
+{ _: ['99.3'] }
+```
+
 ### boolean negation
 
 * default: `true`

--- a/lib/yargs-parser-types.ts
+++ b/lib/yargs-parser-types.ts
@@ -49,6 +49,8 @@ export interface Configuration {
   'nargs-eats-options': boolean;
   /** The prefix to use for negated boolean variables. Default is `'no-'` */
   'negation-prefix': string;
+  /** Should positional values that look like numbers be parsed? Default is `true` */
+  'parse-positional-numbers': boolean;
   /** Should keys that look like numbers be treated as such? Default is `true` */
   'parse-numbers': boolean;
   /** Should unparsed flags be stored in -- or _? Default is `false` */

--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -67,6 +67,7 @@ export class YargsParser {
       'nargs-eats-options': false,
       'negation-prefix': 'no-',
       'parse-numbers': true,
+      'parse-positional-numbers': true,
       'populate--': false,
       'set-placeholder-key': false,
       'short-option-groups': true,
@@ -618,11 +619,14 @@ export class YargsParser {
     }
 
     function maybeCoerceNumber (key: string, value: string | number | null | undefined) {
+      if (!configuration['parse-positional-numbers'] && key === '_') return value
       if (!checkAllAliases(key, flags.strings) && !checkAllAliases(key, flags.bools) && !Array.isArray(value)) {
         const shouldCoerceNumber = isNumber(value) && configuration['parse-numbers'] && (
           Number.isSafeInteger(Math.floor(parseFloat(`${value}`)))
         )
-        if (shouldCoerceNumber || (!isUndefined(value) && checkAllAliases(key, flags.numbers))) value = Number(value)
+        if (shouldCoerceNumber || (!isUndefined(value) && checkAllAliases(key, flags.numbers))) {
+          value = Number(value)
+        }
       }
       return value
     }
@@ -1031,12 +1035,12 @@ export class YargsParser {
     }
 
     return {
-      argv: Object.assign(argvReturn, argv),
-      error: error,
       aliases: Object.assign({}, flags.aliases),
-      newAliases: Object.assign({}, newAliases),
+      argv: Object.assign(argvReturn, argv),
+      configuration: configuration,
       defaulted: Object.assign({}, defaulted),
-      configuration: configuration
+      error: error,
+      newAliases: Object.assign({}, newAliases)
     }
   }
 }

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -2444,6 +2444,24 @@ describe('yargs-parser', function () {
       })
     })
 
+    describe('parse-positional-numbers', () => {
+      it('does not parse positionals into numbers when false', function () {
+        var parsed = parser(['5.0', '3'], {
+          configuration: {
+            'parse-positional-numbers': false
+          }
+        })
+        expect(parsed._[0]).to.equal('5.0')
+        expect(parsed._[1]).to.equal('3')
+      })
+
+      it('parses positionals into numbers by default', function () {
+        var parsed = parser(['5.0', '3'])
+        expect(parsed._[0]).to.equal(5)
+        expect(parsed._[1]).to.equal(3)
+      })
+    })
+
     describe('parse numbers', function () {
       it('does not coerce defaults into numbers', function () {
         var parsed = parser([], {


### PR DESCRIPTION
Adds the `parse-positional-numbers` which allows the coercion of positional arguments that look like numbers to be configured independently from keys that look like numbers.

Refs https://github.com/yargs/yargs/issues/1758