### PR TITLE
fix(unknown-options-as-args): convert positionals that look like numbers

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -212,7 +212,7 @@ export class YargsParser {
 
       // any unknown option (except for end-of-options, "--")
       if (arg !== '--' && isUnknownOptionAsArg(arg)) {
-        argv._.push(arg)
+        pushPositional(arg)
       // -- separated by =
       } else if (arg.match(/^--.+=/) || (
         !configuration['short-option-groups'] && arg.match(/^-.+=/)
@@ -382,10 +382,7 @@ export class YargsParser {
         notFlags = args.slice(i)
         break
       } else {
-        const maybeCoercedNumber = maybeCoerceNumber('_', arg)
-        if (typeof maybeCoercedNumber === 'string' || typeof maybeCoercedNumber === 'number') {
-          argv._.push(maybeCoercedNumber)
-        }
+        pushPositional(arg)
       }
     }
 
@@ -428,6 +425,14 @@ export class YargsParser {
 
         delete argv[alias]
       })
+    }
+
+    // Push argument into positional array, applying numeric coercion:
+    function pushPositional (arg: string) {
+      const maybeCoercedNumber = maybeCoerceNumber('_', arg)
+      if (typeof maybeCoercedNumber === 'string' || typeof maybeCoercedNumber === 'number') {
+        argv._.push(maybeCoercedNumber)
+      }
     }
 
     // how many arguments should we consume, based

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -3072,7 +3072,7 @@ describe('yargs-parser', function () {
           }
         })
         argv.should.deep.equal({
-          _: ['-u.arg', '2'],
+          _: ['-u.arg', 2],
           k: {
             arg: 1
           }
@@ -3110,7 +3110,7 @@ describe('yargs-parser', function () {
           }
         })
         argv.should.deep.equal({
-          _: ['-u', '2'],
+          _: ['-u', 2],
           k: 1
         })
       })
@@ -3256,6 +3256,17 @@ describe('yargs-parser', function () {
           _: ['--hasOwnProperty=33'],
           'known-arg': 1,
           knownArg: 1
+        })
+      })
+
+      it('should coerce unknown options that look numeric into numbers', () => {
+        const argv = parser('--known-arg 33', {
+          boolean: ['known-arg']
+        })
+        argv.should.deep.equal({
+          _: [33],
+          'known-arg': true,
+          knownArg: true
         })
       })
     })


### PR DESCRIPTION
Numeric coercion was not being applied for positionals when `unknown-options-as-args` was `true`.