### PR TITLE
fix(deno): update types for deno ^1.4.0

### DIFF
--- a/deno.ts
+++ b/deno.ts
@@ -5,7 +5,7 @@
 import * as path from 'https://deno.land/std/path/mod.ts'
 import { camelCase, decamelize, looksLikeNumber } from './build/lib/string-utils.js'
 import { YargsParser } from './build/lib/yargs-parser.js'
-import { Arguments, ArgsInput, Parser, Options, DetailedArguments } from './build/lib/yargs-parser-types.d.ts'
+import type { Arguments, ArgsInput, Parser, Options, DetailedArguments } from './build/lib/yargs-parser-types.d.ts'
 
 const parser = new YargsParser({
   cwd: Deno.cwd,


### PR DESCRIPTION
In version 1.4 Deno adopted;

- the tsconfig setting [importsNotUsedAsValues](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) - https://github.com/denoland/deno/pull/7413

This requires the use of;
- type only imports for values which are only used as types (`importsNotUsedAsValues`)

I've added more details at https://github.com/yargs/yargs/issues/1771.

related prs:
- yargs https://github.com/yargs/yargs/pull/1772
- y18n https://github.com/yargs/y18n/pull/100

---

While creating this pr, I was unable to get run the `yarn fix` command, this seems to be an unrelated issue though.

```sh
$ standardx --fix '**/*.ts' && standardx --fix '**/*.js' && standardx --fix '**/*.cjs'
standardx: Unexpected linter output:

Error: Failed to load config "standard" to extend from.
Referenced from: BaseConfig
```

