### PR TITLE
fix(deno): update types for deno ^1.4.0

### DIFF
--- a/deno.ts
+++ b/deno.ts
@@ -5,7 +5,7 @@
 import * as path from 'https://deno.land/std/path/mod.ts'
 import { camelCase, decamelize, looksLikeNumber } from './build/lib/string-utils.js'
 import { YargsParser } from './build/lib/yargs-parser.js'
-import { Arguments, ArgsInput, Parser, Options, DetailedArguments } from './build/lib/yargs-parser-types.d.ts'
+import type { Arguments, ArgsInput, Parser, Options, DetailedArguments } from './build/lib/yargs-parser-types.d.ts'
 
 const parser = new YargsParser({
   cwd: Deno.cwd,


### PR DESCRIPTION
This is a repeat of https://github.com/yargs/yargs-parser/pull/329 targeting the correct branch

---

In version 1.4 Deno adopted;

- the tsconfig setting [importsNotUsedAsValues](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) - https://github.com/denoland/deno/pull/7413

This requires the use of;
- type only imports for values which are only used as types (`importsNotUsedAsValues`)