### PR TITLE
fix(exports): node 13.0-13.6 require a string fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "version": "20.2.1",
   "description": "the mighty option parser used by yargs",
   "main": "build/index.cjs",
-  "exports": {
-    "import": "./build/lib/index.js",
-    "require": "./build/index.cjs"
-  },
+  "exports": [
+    {
+      "import": "./build/lib/index.js",
+      "require": "./build/index.cjs"
+    },
+    "./build/index.cjs"
+  ],
   "type": "module",
   "module": "./build/lib/index.js",
   "scripts": {


### PR DESCRIPTION
package.json’s "engines" field claims yargs-parser supports node >= 10; node v13.0-v13.6 are included in this semver range. This change is required to be able to require() from yargs-parser successfully in these versions.

See https://github.com/yargs/yargs/pull/1776