### PR TITLE
bump 5.0.0-security.0 -> 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yargs-parser",
-  "version": "5.0.0-security.0",
+  "version": "5.0.1",
   "description": "the mighty option parser used by yargs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Using proper semver numbers. `5.0.0-security.0` is technically less than `5.0.0`. This will pacify security errors requiring versions `> 5.0.0`.

<details>
<summary>
<picture>
<source width="925" srcset="https://user-images.githubusercontent.com/1362083/107133749-84bab880-68b9-11eb-8b07-b05194007fe8.png" media="(prefers-color-scheme: dark)">
<img width="927" alt="GHSA-p9pc-299p-vxgp
low severity
Vulnerable versions: <= 5.0.0
Patched version: 5.0.0-security.0
Affected versions of yargs-parser are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of Object, causing the addition or modification of an existing property that will exist on all objects.
Parsing the argument --foo.__proto__.bar baz' adds a bar property with value baz to all objects. This is only exploitable if attackers have control over the arguments being passed to yargs-parser.
Recommendation
Upgrade to versions 13.1.2, 15.0.1, 18.1.1 or later.
" src="https://user-images.githubusercontent.com/1362083/107124269-d3903000-6870-11eb-9bf7-68231f234758.png">
</picture>
</summary>
<blockquote>
<div class="Box Box--condensed">
<div class="Box-row">
<div class="d-flex flex-justify-between flex-items-center pt-2">
<div>
<h5 class="h4 mb-2">
<a class="link-gray-dark no-underline" data-hovercard-type="advisory" data-hovercard-url="/advisories/GHSA-p9pc-299p-vxgp/hovercard" href="/advisories/GHSA-p9pc-299p-vxgp">GHSA-p9pc-299p-vxgp</a>
</h5>
</div>
<div>
<span title="Severity label" class="Label Label--gray-darker ">
low severity
</span>
</div>
</div>
<div>
<b>Vulnerable versions:</b>
<span class="text-mono pl-1">&lt;= 5.0.0</span>
</div>
<div>
<b>Patched version:</b>
<span class="text-mono pl-1">5.0.0-security.0</span>
</div>
<div class="mt-2 markdown-body">
<p>Affected versions of <code>yargs-parser</code> are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of <code>Object</code>, causing the addition or modification of an existing property that will exist on all objects.<br>
Parsing the argument <code>--foo.__proto__.bar baz'</code> adds a <code>bar</code> property with value <code>baz</code> to all objects. This is only exploitable if attackers have control over the arguments being passed to <code>yargs-parser</code>.</p>
<h2>Recommendation</h2>
<p>Upgrade to versions 13.1.2, 15.0.1, 18.1.1 or later.</p>
</div>
</div>
</div>
</blockquote>
</details>

<details>
<summary>
<picture>
<source width="962" srcset="https://user-images.githubusercontent.com/1362083/107133754-8a180300-68b9-11eb-90cf-d982c97432b9.png" media="(prefers-color-scheme: dark)">
<img width="956" alt="Dependabot cannot update yargs-parser to a non-vulnerable version
The latest possible version that can be installed is 5.0.0-security.0 because of the following conflicting dependency:
gulp@4.0.2 requires yargs-parser@5.0.0-security.0 via a transitive dependency on yargs@7.1.1
The earliest fixed version is 13.1.2.
" src="https://user-images.githubusercontent.com/1362083/107125224-9cbd1880-6876-11eb-87a9-ba41b1839322.png">
</picture>
</summary>
<blockquote>
<div class="flash flash-warn mb-3 ">
<h5 data-test-selector="dependabot-security-update-error-title">
<svg class="octicon octicon-alert mr-1" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.22 1.754a.25.25 0 00-.44 0L1.698 13.132a.25.25 0 00.22.368h12.164a.25.25 0 00.22-.368L8.22 1.754zm-1.763-.707c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0114.082 15H1.918a1.75 1.75 0 01-1.543-2.575L6.457 1.047zM9 11a1 1 0 11-2 0 1 1 0 012 0zm-.25-5.25a.75.75 0 00-1.5 0v2.5a.75.75 0 001.5 0v-2.5z"></path></svg>
Dependabot cannot update yargs-parser to a non-vulnerable version
</h5>
<div data-test-selector="dependabot-security-update-error-body">
<div class="comment-body markdown-body py-2 px-0">
<p>The latest possible version that can be installed is <code>5.0.0-security.0</code> because of the following conflicting dependency:</p>
<pre><code>gulp@4.0.2 requires yargs-parser@5.0.0-security.0 via a transitive dependency on yargs@7.1.1
</code></pre>
<p>The earliest fixed version is <code>13.1.2</code>.</p>
</div>
</div>
</div>
</blockquote>
</details>


