### PR TITLE
fix(populate--): -- should always be array

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -218,7 +218,7 @@ export class YargsParser {
       } else if (arg.match(/---+(=|$)/)) {
         // options without key name are invalid.
         pushPositional(arg)
-        continue;
+        continue
       // -- separated by =
       } else if (arg.match(/^--.+=/) || (
         !configuration['short-option-groups'] && arg.match(/^-.+=/)
@@ -412,7 +412,7 @@ export class YargsParser {
     })
 
     // '--' defaults to undefined.
-    if (notFlagsOption && notFlags.length) argv[notFlagsArgv] = [];
+    if (notFlagsOption && notFlags.length) argv[notFlagsArgv] = []
     notFlags.forEach(function (key) {
       argv[notFlagsArgv].push(key)
     })

--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -214,6 +214,11 @@ export class YargsParser {
       // any unknown option (except for end-of-options, "--")
       if (arg !== '--' && isUnknownOptionAsArg(arg)) {
         pushPositional(arg)
+      // ---, ---=, ----, etc,
+      } else if (arg.match(/---+(=|$)/)) {
+        // options without key name are invalid.
+        pushPositional(arg)
+        continue;
       // -- separated by =
       } else if (arg.match(/^--.+=/) || (
         !configuration['short-option-groups'] && arg.match(/^-.+=/)
@@ -407,9 +412,7 @@ export class YargsParser {
     })
 
     // '--' defaults to undefined.
-    if (notFlagsOption && notFlags.length) argv[notFlagsArgv] = []
-    // See: https://github.com/yargs/yargs/issues/1869.
-    if (notFlagsOption && !Array.isArray(argv[notFlagsArgv])) argv[notFlagsArgv] = [argv[notFlagsArgv]]
+    if (notFlagsOption && notFlags.length) argv[notFlagsArgv] = [];
     notFlags.forEach(function (key) {
       argv[notFlagsArgv].push(key)
     })

--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -408,6 +408,8 @@ export class YargsParser {
 
     // '--' defaults to undefined.
     if (notFlagsOption && notFlags.length) argv[notFlagsArgv] = []
+    // See: https://github.com/yargs/yargs/issues/1869.
+    if (notFlagsOption && !Array.isArray(argv[notFlagsArgv])) argv[notFlagsArgv] = [argv[notFlagsArgv]]
     notFlags.forEach(function (key) {
       argv[notFlagsArgv].push(key)
     })

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -3252,8 +3252,8 @@ describe('yargs-parser', function () {
             'populate--': true
           }
         })
-        argv['_'].should.eql(['----=test'])
-        expect(argv['--']).to.equal(undefined);
+        argv._.should.eql(['----=test'])
+        expect(argv['--']).to.equal(undefined)
       })
       // see: https://github.com/yargs/yargs/issues/1489
       it('should identify "hasOwnProperty" as unknown option', () => {

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -3245,16 +3245,15 @@ describe('yargs-parser', function () {
         })
       })
       // See: https://github.com/yargs/yargs/issues/1869
-      // TODO(@bcoe): add additional test cases for handling of edge cases like
       // ----=hello ---=hello ---- hello.
-      it('should default -- to arrray when populate-- set', () => {
+      it('should not populate "--" for key values other than "--"', () => {
         const argv = parser('----=test', {
           configuration: {
             'populate--': true
           }
         })
-        argv['--'].should.eql(['test'])
-        argv[''].should.eql(['test'])
+        argv['_'].should.eql(['----=test'])
+        expect(argv['--']).to.equal(undefined);
       })
       // see: https://github.com/yargs/yargs/issues/1489
       it('should identify "hasOwnProperty" as unknown option', () => {

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -3244,6 +3244,18 @@ describe('yargs-parser', function () {
           k: true
         })
       })
+      // See: https://github.com/yargs/yargs/issues/1869
+      // TODO(@bcoe): add additional test cases for handling of edge cases like
+      // ----=hello ---=hello ---- hello.
+      it('should default -- to arrray when populate-- set', () => {
+        const argv = parser('----=test', {
+          configuration: {
+            'populate--': true
+          }
+        })
+        argv['--'].should.eql(['test'])
+        argv[''].should.eql(['test'])
+      })
       // see: https://github.com/yargs/yargs/issues/1489
       it('should identify "hasOwnProperty" as unknown option', () => {
         const argv = parser('--known-arg=1 --hasOwnProperty=33', {


### PR DESCRIPTION
If `populate--` has been set, then `--` should be coerced into an array.

Fixes: https://github.com/yargs/yargs/issues/1869