### PR TITLE
fix: enable ansi-c escape quoting

### DIFF
--- a/lib/tokenize-arg-string.ts
+++ b/lib/tokenize-arg-string.ts
@@ -1,7 +1,47 @@
+
+/*
+ * This is *only* for bash ANSI-C quoted strings - that is, strings that match the pattern $'some text'
+ *
+ * It's a fairly rare case but leads to the occasional bug. Only implementing the escaped string replacement will most
+ * likely fix the vast majority of these bugs.
+ *
+ * Javascript strings already process some of these correctly (newlines, unicode strings, carriage returns, etc)
+ *
+ * Additional documentation
+ * https://www.gnu.org/software/bash/manual/bash.html#ANSI_002dC-Quoting
+ *
+ * Original issue report: https://github.com/NickCarneiro/curlconverter/issues/207
+ */
+export function escapeAnsiString (str: string): string {
+  return str
+    .replace(/\\'/g, "'")
+    .replace(/\\"/g, '"')
+    .replace(/\\\?/g, '?')
+    .replace(/\\a/g, '\a') // eslint-disable-line
+    .replace(/\\b/g, '\b')
+    .replace(/\\f/g, '\f')
+    .replace(/\\v/g, '\v')
+    .replace(/\\r/g, '\r')
+    .replace(/\\n/g, '\n')
+    .replace(/\\\\/g, '\\')
+}
+
+const ANSI_REGEX = /\$('.*')/s
+export function escapeAnsiCQuotes (stringArr: string[]): string[] {
+  return (stringArr || []).map(str => {
+    const match = (str || '').match(ANSI_REGEX)
+    if (match && match.length > 1) {
+      const matchGroup = match[1]
+      return str.replace(ANSI_REGEX, escapeAnsiString(matchGroup))
+    }
+    return str
+  })
+}
+
 // take an un-split argv string and tokenize it.
 export function tokenizeArgString (argString: string | any[]): string[] {
   if (Array.isArray(argString)) {
-    return argString.map(e => typeof e !== 'string' ? e + '' : e)
+    return escapeAnsiCQuotes(argString.map(e => typeof e !== 'string' ? e + '' : e))
   }
 
   argString = argString.trim()
@@ -36,5 +76,5 @@ export function tokenizeArgString (argString: string | any[]): string[] {
     args[i] += c
   }
 
-  return args
+  return escapeAnsiCQuotes(args)
 }

--- a/lib/tokenize-arg-string.ts
+++ b/lib/tokenize-arg-string.ts
@@ -1,11 +1,8 @@
-
 /*
  * This is *only* for bash ANSI-C quoted strings - that is, strings that match the pattern $'some text'
  *
- * It's a fairly rare case but leads to the occasional bug. Only implementing the escaped string replacement will most
- * likely fix the vast majority of these bugs.
- *
- * Javascript strings already process some of these correctly (newlines, unicode strings, carriage returns, etc)
+ * It's a fairly rare case but leads to the occasional bug (most notably when copying from Chrome or Firefox devtools).
+ * Implementing the escaped string replacement will most likely fix the vast majority of these bugs.
  *
  * Additional documentation
  * https://www.gnu.org/software/bash/manual/bash.html#ANSI_002dC-Quoting

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -3935,6 +3935,11 @@ describe('yargs-parser', function () {
     })
   })
 
+  it('parses ANSI-C quotes properly', () => {
+    const argv = parser(['--string', "$'text with \\n newline'"])
+    argv.should.have.property('string', 'text with \n newline')
+  })
+
   it('should replace the key __proto__ with the key ___proto___', function () {
     const argv = parser(['-f.__proto__.foo', '99', '-x.y.__proto__.bar', '100', '--__proto__', '200'])
     argv.should.eql({


### PR DESCRIPTION
Fix for https://github.com/yargs/yargs-parser/issues/346

I think there should be at least a little discussion around this change. 

In general, this seems very safe. it's effectively only fixing bugs. It doesn't go _all_ the way, though - in bash, the escape sequence with \b looks like this:

```
$ echo $'fixx\b me'
fix me
```

where as in this version it'll print out `fixx me`. I'm not sure implementing character deletion makes sense, though - perhaps we could hide actual mutations to the input like this through an option? 

In general this code path is going to be hit so rarely that I don't think it matters _that_ much. Just think people should be aware of it. 

There's also escape sequences like bell which we silently strip out. 
