### PR TITLE
Add license comments to all source files

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,12 @@
-// Main entrypoint for libraries using yargs-parser in Node.js
-// CJS and ESM environments:
+/**
+ * @fileoverview Main entrypoint for libraries using yargs-parser in Node.js
+ * CJS and ESM environments.
+ *
+ * @license
+ * Copyright (c) 2016, Contributors
+ * SPDX-License-Identifier: ISC
+ */
+
 import { format } from 'util'
 import { readFileSync } from 'fs'
 import { normalize, resolve } from 'path'

--- a/lib/string-utils.ts
+++ b/lib/string-utils.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright (c) 2016, Contributors
+ * SPDX-License-Identifier: ISC
+ */
+
 export function camelCase (str: string): string {
   // Handle the case where an argument is provided as camel case, e.g., fooBar.
   // by ensuring that the string isn't already mixed case:

--- a/lib/tokenize-arg-string.ts
+++ b/lib/tokenize-arg-string.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright (c) 2016, Contributors
+ * SPDX-License-Identifier: ISC
+ */
+
 // take an un-split argv string and tokenize it.
 export function tokenizeArgString (argString: string | any[]): string[] {
   if (Array.isArray(argString)) {

--- a/lib/yargs-parser-types.ts
+++ b/lib/yargs-parser-types.ts
@@ -1,4 +1,10 @@
 /**
+ * @license
+ * Copyright (c) 2016, Contributors
+ * SPDX-License-Identifier: ISC
+ */
+
+/**
  * An object whose all properties have the same type, where each key is a string.
  */
 export interface Dictionary<T = any> {

--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright (c) 2016, Contributors
+ * SPDX-License-Identifier: ISC
+ */
+
 import { tokenizeArgString } from './tokenize-arg-string.js'
 import type {
   ArgsInput,


### PR DESCRIPTION
This change allows automated extraction of the proper license attributions when bundling the contents. See [closure compiler docs as an example](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#license-preserve-description). The format is also [recognized by terser](https://webpack.js.org/plugins/terser-webpack-plugin/#extractcomments).

Fixes #369