### PR TITLE
fix(perf): address slow parse when using unknown-options-as-args

### DIFF
--- a/index.js
+++ b/index.js
@@ -813,6 +813,7 @@ function parse (args, opts) {
   }
 
   function isUnknownOption (arg) {
+    arg = arg.replace(/^-{3,}/, '---')
     // ignore negative numbers
     if (arg.match(negative)) { return false }
     // if this is a short option group and all of them are configured, it isn't unknown

--- a/test/yargs-parser.js
+++ b/test/yargs-parser.js
@@ -3301,4 +3301,37 @@ describe('yargs-parser', function () {
     expect({}.foo).to.equal(undefined)
     expect({}.bar).to.equal(undefined)
   })
+
+  // Refs: https://github.com/yargs/yargs-parser/issues/386
+  describe('perf', () => {
+    const i = 100000
+    describe('unknown-options-as-args', () => {
+      it('parses long chain of "-" with reasonable performance', function () {
+        this.timeout(500)
+        const s = (new Array(i).fill('-').join('')) + 'a'
+        const parsed = parser([s], { configuration: { 'unknown-options-as-args': true } })
+        parsed._[0].should.equal(s)
+      })
+      it('parses long chain of "-a-a" with reasonable performance', function () {
+        this.timeout(500)
+        const s = '-' + (new Array(i).fill('-a').join('')) + '=35'
+        const parsed = parser([s], { configuration: { 'unknown-options-as-args': true } })
+        parsed._[0].should.equal(s)
+      })
+    })
+    it('parses long chain of "-" with reasonable performance', function () {
+      this.timeout(500)
+      const s = (new Array(i).fill('-').join('')) + 'a'
+      const arg = (new Array(i - 2).fill('-').join('')) + 'a'
+      const parsed = parser([s])
+      parsed[arg].should.equal(true)
+    })
+    it('parses long chain of "-a-a" with reasonable performance', function () {
+      this.timeout(500)
+      const s = '-' + (new Array(i).fill('-a').join('')) + '=35'
+      const arg = 'a' + (new Array(i - 1).fill('A').join(''))
+      const parsed = parser([s])
+      parsed[arg].should.equal(35)
+    })
+  })
 })


### PR DESCRIPTION
back-port #394 to 15.x release line.