### PR TITLE
fix: parser should preserve inner quotes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,5 +42,5 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_MONOREPO_TOKEN}}
         if: ${{ steps.release.outputs.releases_created }}

--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -557,7 +557,6 @@ export class YargsParser {
         addNewAlias(key, alias)
       }
 
-      console.log({val})
       const value = processValue(key, val, shouldStripQuotes)
       const splitKey = key.split('.')
       setKey(argv, splitKey, value)

--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -59,6 +59,9 @@ export class YargsParser {
     // allow a string argument to be passed in rather
     // than an argv array.
     const args = tokenizeArgString(argsInput)
+    // tokenizeArgString adds extra quotes to args if argsInput is a string
+    // only strip those extra quotes in processValue if argsInput is a string
+    const shouldStripQuotes = typeof argsInput === 'string'
 
     // aliases might have transitive relationships, normalize this.
     const aliases = combineAliases(Object.assign(Object.create(null), opts.alias))
@@ -243,7 +246,13 @@ export class YargsParser {
             // nargs format = '--f=monkey washing cat'
             i = eatNargs(i, m[1], args, m[2])
           } else {
-            setArg(m[1], m[2])
+            // only strip quotes if they wouldn't already be removed
+            if (shouldStripQuotes) {
+              setArg(m[1], m[2])
+            } else {
+              setArg(m[1], stripQuotes(m[2]))
+            }
+            
           }
         }
       } else if (arg.match(negatedBoolean) && configuration['boolean-negation']) {
@@ -516,7 +525,7 @@ export class YargsParser {
       } else {
         // value in --option=value is eaten as is
         if (!isUndefined(argAfterEqualSign)) {
-          argsToSet.push(processValue(key, argAfterEqualSign))
+          argsToSet.push(processValue(key, argAfterEqualSign, true))
         }
         for (let ii = i + 1; ii < args.length; ii++) {
           if ((!configuration['greedy-arrays'] && argsToSet.length > 0) ||
@@ -524,7 +533,7 @@ export class YargsParser {
           next = args[ii]
           if (/^-/.test(next) && !negative.test(next) && !isUnknownOptionAsArg(next)) break
           i = ii
-          argsToSet.push(processValue(key, next))
+          argsToSet.push(processValue(key, next, shouldStripQuotes))
         }
       }
 
@@ -548,7 +557,8 @@ export class YargsParser {
         addNewAlias(key, alias)
       }
 
-      const value = processValue(key, val)
+      console.log({val})
+      const value = processValue(key, val, shouldStripQuotes)
       const splitKey = key.split('.')
       setKey(argv, splitKey, value)
 
@@ -605,13 +615,10 @@ export class YargsParser {
       }
     }
 
-    function processValue (key: string, val: any) {
+    function processValue (key: string, val: any, shouldStripQuotes: boolean) {
       // strings may be quoted, clean this up as we assign values.
-      if (typeof val === 'string' &&
-        (val[0] === "'" || val[0] === '"') &&
-        val[val.length - 1] === val[0]
-      ) {
-        val = val.substring(1, val.length - 1)
+      if (shouldStripQuotes) {
+        val = stripQuotes(val)
       }
 
       // handle parsing boolean arguments --foo=true --bar false.
@@ -1115,4 +1122,14 @@ function increment (orig?: number | undefined): number {
 function sanitizeKey (key: string): string {
   if (key === '__proto__') return '___proto___'
   return key
+}
+
+function stripQuotes(val: string): string {
+  return (
+    typeof val === 'string' &&
+    (val[0] === "'" || val[0] === '"') &&
+    val[val.length - 1] === val[0]
+  )
+    ? val = val.substring(1, val.length - 1)
+    : val
 }

--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -61,7 +61,7 @@ export class YargsParser {
     const args = tokenizeArgString(argsInput)
     // tokenizeArgString adds extra quotes to args if argsInput is a string
     // only strip those extra quotes in processValue if argsInput is a string
-    const shouldStripQuotes = typeof argsInput === 'string'
+    const inputIsString = typeof argsInput === 'string'
 
     // aliases might have transitive relationships, normalize this.
     const aliases = combineAliases(Object.assign(Object.create(null), opts.alias))
@@ -246,13 +246,7 @@ export class YargsParser {
             // nargs format = '--f=monkey washing cat'
             i = eatNargs(i, m[1], args, m[2])
           } else {
-            // only strip quotes if they wouldn't already be removed
-            if (shouldStripQuotes) {
-              setArg(m[1], m[2])
-            } else {
-              setArg(m[1], stripQuotes(m[2]))
-            }
-            
+            setArg(m[1], m[2], true)
           }
         }
       } else if (arg.match(negatedBoolean) && configuration['boolean-negation']) {
@@ -533,7 +527,7 @@ export class YargsParser {
           next = args[ii]
           if (/^-/.test(next) && !negative.test(next) && !isUnknownOptionAsArg(next)) break
           i = ii
-          argsToSet.push(processValue(key, next, shouldStripQuotes))
+          argsToSet.push(processValue(key, next, inputIsString))
         }
       }
 
@@ -549,7 +543,7 @@ export class YargsParser {
       return i
     }
 
-    function setArg (key: string, val: any): void {
+    function setArg (key: string, val: any, shouldStripQuotes: boolean = inputIsString): void {
       if (/-/.test(key) && configuration['camel-case-expansion']) {
         const alias = key.split('.').map(function (prop) {
           return camelCase(prop)
@@ -1123,12 +1117,12 @@ function sanitizeKey (key: string): string {
   return key
 }
 
-function stripQuotes(val: string): string {
+function stripQuotes (val: string): string {
   return (
     typeof val === 'string' &&
     (val[0] === "'" || val[0] === '"') &&
     val[val.length - 1] === val[0]
   )
-    ? val = val.substring(1, val.length - 1)
+    ? val.substring(1, val.length - 1)
     : val
 }

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -3590,7 +3590,6 @@ describe('yargs-parser', function () {
 
     it('respects inner quotes (string)', function () {
       const args = parser('cmd --foo ""Hello"" --bar ""World"" --baz="":)""')
-      console.log('string', {args})
       args.foo.should.equal('"Hello"')
       args.bar.should.equal('"World"')
       args.baz.should.equal('":)"')
@@ -3598,7 +3597,6 @@ describe('yargs-parser', function () {
 
     it('respects inner quotes (array)', function () {
       const args = parser(['cmd', '--foo', '"Hello"', '--bar', '"World"', '--baz="":)""'])
-      console.log('array', {args})
       args.foo.should.equal('"Hello"')
       args.bar.should.equal('"World"')
       args.baz.should.equal('":)"')

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -3587,6 +3587,22 @@ describe('yargs-parser', function () {
       args.foo.should.equal('-hello world')
       args.bar.should.equal('--goodnight moon')
     })
+
+    it.only('respects inner quotes (string)', function () {
+      const args = parser('cmd --foo ""Hello"" --bar ""World"" --baz "":)""')
+      console.log('string', {args})
+      args.foo.should.equal('"Hello"')
+      args.bar.should.equal('"World"')
+      args.baz.should.equal('":)"')
+    })
+
+    it.only('respects inner quotes (array)', function () {
+      const args = parser(['cmd', '--foo', '"Hello"', '--bar', '"World"', '--baz', '":)"'])
+      console.log('array', {args})
+      args.foo.should.equal('"Hello"')
+      args.bar.should.equal('"World"')
+      args.baz.should.equal('":)"')
+    })
   })
 
   // see: https://github.com/yargs/yargs-parser/issues/144

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -3588,7 +3588,7 @@ describe('yargs-parser', function () {
       args.bar.should.equal('--goodnight moon')
     })
 
-    it.only('respects inner quotes (string)', function () {
+    it('respects inner quotes (string)', function () {
       const args = parser('cmd --foo ""Hello"" --bar ""World"" --baz "":)""')
       console.log('string', {args})
       args.foo.should.equal('"Hello"')
@@ -3596,7 +3596,7 @@ describe('yargs-parser', function () {
       args.baz.should.equal('":)"')
     })
 
-    it.only('respects inner quotes (array)', function () {
+    it('respects inner quotes (array)', function () {
       const args = parser(['cmd', '--foo', '"Hello"', '--bar', '"World"', '--baz', '":)"'])
       console.log('array', {args})
       args.foo.should.equal('"Hello"')

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -3569,7 +3569,7 @@ describe('yargs-parser', function () {
       args.foo.should.equal('hello world')
       args.bar.should.equal('goodnight\'moon')
       const args2 = parser(['--foo', '"hello world"', '--bar="goodnight\'moon"'])
-      args2.foo.should.equal('hello world')
+      args2.foo.should.equal('"hello world"')
       args2.bar.should.equal('goodnight\'moon')
     })
 
@@ -3578,7 +3578,7 @@ describe('yargs-parser', function () {
       args.foo.should.equal('hello world')
       args.bar.should.equal('goodnight"moon')
       const args2 = parser(['--foo', "'hello world'", "--bar='goodnight\"moon'"])
-      args2.foo.should.equal('hello world')
+      args2.foo.should.equal("'hello world'")
       args2.bar.should.equal('goodnight"moon')
     })
 
@@ -3589,7 +3589,7 @@ describe('yargs-parser', function () {
     })
 
     it('respects inner quotes (string)', function () {
-      const args = parser('cmd --foo ""Hello"" --bar ""World"" --baz "":)""')
+      const args = parser('cmd --foo ""Hello"" --bar ""World"" --baz="":)""')
       console.log('string', {args})
       args.foo.should.equal('"Hello"')
       args.bar.should.equal('"World"')
@@ -3597,7 +3597,7 @@ describe('yargs-parser', function () {
     })
 
     it('respects inner quotes (array)', function () {
-      const args = parser(['cmd', '--foo', '"Hello"', '--bar', '"World"', '--baz', '":)"'])
+      const args = parser(['cmd', '--foo', '"Hello"', '--bar', '"World"', '--baz="":)""'])
       console.log('array', {args})
       args.foo.should.equal('"Hello"')
       args.bar.should.equal('"World"')


### PR DESCRIPTION
Addresses: https://github.com/yargs/yargs/issues/1324

## Problem

Inner quotes are handled differently by `parse`, depending on the `argsInput` argument's type.

`tokenizeArgString` wraps `argString` with extra quotes if it is a string.
`tokenizeArgString`  does not do the same for `argString`, if it is an array.
The first code block in `processValue` removes quotes from the value. 

### TLDR

If parse was given a string, extra quotes are added (tokenizeArgString) and then removed (processValue).
If parse was given an array, quotes are removed (processValue). This causes loss of inner quotes.

### Example (using tests)

logs for string with inner quotes

```
{ argsInput: 'cmd --foo ""Hello"" --bar ""World"" --baz "":)""' }

during tokenizeArgString 
{ 
  argString: 'cmd --foo ""Hello"" --bar ""World"" --baz "":)""' }
  args: [  'cmd',  '--foo',  '""Hello""',  '--bar',  '""World""',  '--baz', '"":)""'  ]
}

after processValue 
{
  argv: [Object: null prototype] {
    _: [ 'cmd' ],
    foo: '"Hello"',
    bar: '"World"',
    baz: '":)"'
  }
}

result
{ args: { _: [ 'cmd' ], foo: '"Hello"', bar: '"World"', baz: '":)"' } }
```

logs for array with inner quotes

```
{ argsInput: [  'cmd',   '--foo',  '"Hello"', '--bar',  '"World"',   '--baz',   '":)"'  ] }

during tokenizeArgString 
{
  argString: [  'cmd',   '--foo',  '"Hello"', '--bar',  '"World"', '--baz',  '":)"'  ]
  args: [  'cmd',  '--foo',  '"Hello"', '--bar', '"World"', '--baz',  '":)"'  ]
}

after processValue
{
  argv: [Object: null prototype] {
    _: [ 'cmd' ],
    foo: 'Hello',
    bar: 'World',
    baz: ':)' // *** inner quotes missing ***
  }
}
result 
{ args: { _: [ 'cmd' ], foo: 'Hello', bar: 'World', baz: ':)' } }
```

## Solution

I added conditional logic around removing quotes. I feel like my current solution is messy. I would love to hear your thoughts/advice on this. I know you're busy, so no worries if you don't have time. I will try to find a better solution.

There might be follow up work in yargs for handling positionals. The parsed object that gets returned by yargs-parser still has the positional arguments in `argv._`, 

`const parsed = this.#shim.Parser.detailed(...)`
