### PR TITLE
fix: parse options ending with 3+ hyphens

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -225,7 +225,7 @@ export class YargsParser {
       if (arg !== '--' && isUnknownOptionAsArg(arg)) {
         pushPositional(arg)
       // ---, ---=, ----, etc,
-      } else if (truncatedArg.match(/---+(=|$)/)) {
+      } else if (truncatedArg.match(/^---+(=|$)/)) {
         // options without key name are invalid.
         pushPositional(arg)
         continue


### PR DESCRIPTION
Options ending with three or more hyphens were being parsed as positional arguments because the `options without key name` regular expression didn't have a `^` beginning anchor.

* Closes #433
* Related to #354