### PR TITLE
fix(halt-at-non-option): prevent known args from being parsed when "unknown-options-as-args" is enabled

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -222,7 +222,7 @@ export class YargsParser {
       let value: string
 
       // any unknown option (except for end-of-options, "--")
-      if (arg !== '--' && isUnknownOptionAsArg(arg)) {
+      if (arg !== '--' && /^-/.test(arg) && isUnknownOptionAsArg(arg)) {
         pushPositional(arg)
       // ---, ---=, ----, etc,
       } else if (truncatedArg.match(/^---+(=|$)/)) {

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -3008,6 +3008,16 @@ describe('yargs-parser', function () {
           _: ['./file.js', '--foo', '--', 'barbar']
         })
       })
+
+      it('is not influenced by unknown options when "unknown-options-as-args" is true', function () {
+        const parse = parser(
+          ['-v', '--long', 'arg', './file.js', '--foo', '--', 'barbar'],
+          { configuration: { 'halt-at-non-option': true, 'unknown-options-as-args': true }, boolean: ['foo'] }
+        )
+        parse.should.deep.equal({
+          _: ['-v', '--long', 'arg', './file.js', '--foo', '--', 'barbar']
+        })
+      })
     })
 
     describe('unknown-options-as-args = true', function () {


### PR DESCRIPTION
Closes #437

The test case included in this PR has a simple reproduction of a scenario I've encountered where I want parse all options up to a non-option. All options after this argument should be considered unknown, including `--`.

Essentially, the use case that this accounts for is when a CLI provides two ways to indicate that the remainder of the argument list should not be parsed: by passing a non-option argument (enabling `halt-at-non-option`), or by passing `--` (enabling `populate--`). In addition to this, unknown options provided before the script are collected separately by enabling `unknown-options-as-args`. In my use case, these unknown options are Node.js CLI args that I forward to a child process.