### PR TITLE
Run linting on `*.mjs` files as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "type": "module",
   "module": "./build/lib/index.js",
   "scripts": {
-    "check": "standardx '**/*.ts' && standardx '**/*.js' && standardx '**/*.cjs'",
-    "fix": "standardx --fix '**/*.ts' && standardx --fix '**/*.js' && standardx --fix '**/*.cjs'",
+    "check": "standardx '**/*.ts' && standardx '**/*.js' && standardx '**/*.cjs'&& standardx '**/*.mjs'",
+    "fix": "standardx --fix '**/*.ts' && standardx --fix '**/*.js' && standardx --fix '**/*.cjs' && standardx --fix '**/*.mjs'",
     "pretest": "rimraf build && tsc -p tsconfig.test.json && cross-env NODE_ENV=test npm run build:cjs",
     "test": "c8 --reporter=text --reporter=html mocha test/*.cjs",
     "test:esm": "c8 --reporter=text --reporter=html mocha test/*.mjs",


### PR DESCRIPTION
Will highlight the linting issues we encountered in `standard`: https://github.com/standard/standard/issues/1777#issuecomment-1103931191

Also: Since you're not running stock `standard` I guess its best if we remove you from our list of modules to regression test?