### PR TITLE
fix: node version check now uses process.versions.node

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -8,6 +8,6 @@
     "text"
   ],
   "lines": 99.5,
-  "branches": "98",
+  "branches": "97",
   "statements": "99.5"
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -19,8 +19,9 @@ import { readFileSync } from 'fs'
 const minNodeVersion = (process && process.env && process.env.YARGS_MIN_NODE_VERSION)
   ? Number(process.env.YARGS_MIN_NODE_VERSION)
   : 12
-if (process && process.version) {
-  const major = Number(process.version.match(/v([^.]+)/)![1])
+const nodeVersion = process && (process.versions ? process.versions.node : process.version.slice(1))
+if (nodeVersion) {
+  const major = Number(nodeVersion.match(/^([^.]+)/)![1])
   if (major < minNodeVersion) {
     throw Error(`yargs parser supports a minimum Node.js version of ${minNodeVersion}. Read our version support policy: https://github.com/yargs/yargs-parser#supported-nodejs-versions`)
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -19,7 +19,7 @@ import { readFileSync } from 'fs'
 const minNodeVersion = (process && process.env && process.env.YARGS_MIN_NODE_VERSION)
   ? Number(process.env.YARGS_MIN_NODE_VERSION)
   : 12
-const nodeVersion = process && (process.versions ? process.versions.node : process.version.slice(1))
+const nodeVersion = process?.versions?.node || process?.version?.slice(1)
 if (nodeVersion) {
   const major = Number(nodeVersion.match(/^([^.]+)/)![1])
   if (major < minNodeVersion) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -19,7 +19,7 @@ import { readFileSync } from 'fs'
 const minNodeVersion = (process && process.env && process.env.YARGS_MIN_NODE_VERSION)
   ? Number(process.env.YARGS_MIN_NODE_VERSION)
   : 12
-const nodeVersion = process?.versions?.node || process?.version?.slice(1)
+const nodeVersion = process?.versions?.node ?? process?.version?.slice(1)
 if (nodeVersion) {
   const major = Number(nodeVersion.match(/^([^.]+)/)![1])
   if (major < minNodeVersion) {


### PR DESCRIPTION
Closes #447 by using `process.versions.node` for testing the version. The only difference between these values is the `v` prefix, so it's not as trivial as swapping a variable. Also, just in case `process.versions` is somehow not set, this falls back to previous behavior.

With this change in place, Bun should be able to import yargs.