### PR TITLE
Prefer sending args to `_` when both `halt-at-non-option` and `populate--` are enabled

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -395,7 +395,7 @@ export class YargsParser {
         notFlags = args.slice(i + 1)
         break
       } else if (configuration['halt-at-non-option']) {
-        notFlags = args.slice(i)
+        args.slice(i).forEach(pushPositional)
         break
       } else {
         pushPositional(arg)

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -2997,6 +2997,17 @@ describe('yargs-parser', function () {
         })
       })
 
+      it('should push to _ when populate-- is true', function () {
+        const parse = parser(
+          ['--foo', './file.js', '--foo', '--', 'barbar', '--bar'],
+          { configuration: { 'halt-at-non-option': true, 'populate--': true }, boolean: ['foo', 'bar'] }
+        )
+        parse.should.deep.equal({
+          foo: true,
+          _: ['./file.js', '--foo', '--', 'barbar', '--bar']
+        })
+      })
+
       it('is not influenced by unknown options', function () {
         const parse = parser(
           ['-v', '--long', 'arg', './file.js', '--foo', '--', 'barbar'],


### PR DESCRIPTION
Fixes (part of) #453

There is currently an undocumented interaction between `halt-at-non-option` and `populate--` where the remaining args are sent to `--` when `populate--` is true, and `_` when it's false. There doesn't seem to be any tests enforcing this behavior, and it causes subcommand handling in `yargs` to break down. Given that this was a latent bug when combined with `unknown-options-as-args: true` (which was fixed in v21.1.0 by #438), I think it will be the least disruptive to ensure that `populate--` has no effect on the behavior of this parse option.