### PR TITLE
fix(halt-at-non-option): revert: prevent known args from being parsed when "unknown-options-as-args" is enabled"

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -222,7 +222,7 @@ export class YargsParser {
       let value: string
 
       // any unknown option (except for end-of-options, "--")
-      if (arg !== '--' && /^-/.test(arg) && isUnknownOptionAsArg(arg)) {
+      if (arg !== '--' && isUnknownOptionAsArg(arg)) {
         pushPositional(arg)
       // ---, ---=, ----, etc,
       } else if (truncatedArg.match(/^---+(=|$)/)) {

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -3008,16 +3008,6 @@ describe('yargs-parser', function () {
           _: ['./file.js', '--foo', '--', 'barbar']
         })
       })
-
-      it('is not influenced by unknown options when "unknown-options-as-args" is true', function () {
-        const parse = parser(
-          ['-v', '--long', 'arg', './file.js', '--foo', '--', 'barbar'],
-          { configuration: { 'halt-at-non-option': true, 'unknown-options-as-args': true }, boolean: ['foo'] }
-        )
-        parse.should.deep.equal({
-          _: ['-v', '--long', 'arg', './file.js', '--foo', '--', 'barbar']
-        })
-      })
     })
 
     describe('unknown-options-as-args = true', function () {


### PR DESCRIPTION
I'm supportive of this change to the parser, but there are a couple edge-cases we need to fix, and we should probably land it as a breaking change so that #453 can stay on an older version of the parser.

Reverts yargs/yargs-parser#438