### PR TITLE
Allow repeated config options

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -659,8 +659,13 @@ export class YargsParser {
       applyDefaultsAndAliases(configLookup, flags.aliases, defaults)
 
       Object.keys(flags.configs).forEach(function (configKey) {
-        const configPath = argv[configKey] || configLookup[configKey]
-        if (configPath) {
+        var configPaths = argv[configKey] || configLookup[configKey]
+
+        if (typeof configPaths === "string") {
+          configPaths = [configPaths]
+        }
+
+        configPaths.forEach(function (configPath : string) {
           try {
             let config = null
             const resolvedConfigPath = mixin.resolve(mixin.cwd(), configPath)
@@ -687,7 +692,7 @@ export class YargsParser {
             if (ex.name === 'PermissionDenied') error = ex
             else if (argv[configKey]) error = Error(__('Invalid JSON config file: %s', configPath))
           }
-        }
+        })
       })
     }
 

--- a/test/yargs-parser.cjs
+++ b/test/yargs-parser.cjs
@@ -597,6 +597,19 @@ describe('yargs-parser', function () {
       argv.should.have.property('foo').and.deep.equal('bar')
     })
 
+    // see https://github.com/yargs/yargs-parser/issues/430
+    it("should allow repeated config options", function () {
+      const argv = parser(['--settings', jsonPath, '--settings', jsonPath], {
+        alias: {
+          z: 'zoom'
+        },
+        config: ['settings']
+      })
+
+      argv.should.have.property('herp', 'derp')
+      argv.should.have.property('zoom', 55)
+    })
+
     it('should load options and values from a JS file when config has .js extention', function () {
       const jsPath = path.resolve(__dirname, './fixtures/settings.cjs')
       const argv = parser(['--settings', jsPath, '--foo', 'bar'], {

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -112,6 +112,19 @@ describe('yargs-parser (esm)', function () {
       argv.should.have.property('foo').and.deep.equal('bar')
     })
 
+    // see https://github.com/yargs/yargs-parser/issues/430
+    it("should allow repeated config options", function () {
+      const argv = parser(['--settings', jsonPath, '--settings', jsonPath], {
+        alias: {
+          z: 'zoom'
+        },
+        config: ['settings']
+      })
+
+      argv.should.have.property('herp', 'derp')
+      argv.should.have.property('zoom', 55)
+    })
+
     // for esm, only support importing json files
     it('should fail to load options and values from a JS file when config has .js extention', function () {
       const jsPath = path.resolve(__dirname, './fixtures/settings.cjs')


### PR DESCRIPTION
Adds tests for https://github.com/yargs/yargs-parser/issues/430 and makes them pass, but I am open to being told that this is in some way not ideal.