### PR TITLE
fix(deno): specify deps (avoids Deno warnings)

### DIFF
--- a/deno.ts
+++ b/deno.ts
@@ -2,7 +2,7 @@
 // Main entrypoint for Deno.
 //
 // TODO: find reasonable replacement for require logic.
-import * as path from 'https://deno.land/std/path/mod.ts'
+import * as path from 'https://deno.land/std@0.159.0/path/mod.ts'
 import { camelCase, decamelize, looksLikeNumber } from './build/lib/string-utils.js'
 import { YargsParser } from './build/lib/yargs-parser.js'
 import type { Arguments, ArgsInput, Parser, Options, DetailedArguments } from './build/lib/yargs-parser-types.d.ts'

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -39,6 +39,7 @@ const parser = new YargsParser({
   resolve,
   // TODO: figure  out a  way to combine ESM and CJS coverage, such  that
   // we can exercise all the lines below:
+  /* c8 ignore start */
   require: (path: string) => {
     if (typeof require !== 'undefined') {
       return require(path)
@@ -49,6 +50,7 @@ const parser = new YargsParser({
       throw Error('only .json config files are supported in ESM')
     }
   }
+  /* c8 ignore stop */
 })
 const yargsParser: Parser = function Parser (args: ArgsInput, opts?: Partial<Options>): Arguments {
   const result = parser.parse(args.slice(), opts)

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "devDependencies": {
+    "@rollup/plugin-typescript": "^8.5.0",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.4",
@@ -68,11 +69,11 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.22.1",
     "rollup-plugin-cleanup": "^3.1.1",
-    "rollup-plugin-ts": "^3.0.2",
     "serve": "^14.0.0",
     "standardx": "^7.0.0",
     "start-server-and-test": "^1.11.2",
     "ts-transform-default-export": "^1.0.2",
+    "tslib": "^2.4.1",
     "typescript": "^4.0.0"
   },
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 import cleanup from 'rollup-plugin-cleanup'
-import ts from 'rollup-plugin-ts'
+import ts from '@rollup/plugin-typescript'
 import transformDefaultExport from 'ts-transform-default-export'
 
 const output = {


### PR DESCRIPTION
The current version causes Deno to report warnings when imported. 
This PR pins the version to the current Deno std (0.159.0) and removes the warnings.

```shell
$ deno run -r deno.ts
Warning Implicitly using latest version (0.159.0) for https://deno.land/std/path/mod.ts

$ git checkout fix.deno
Previous HEAD position was 3aba24c chore(main): release yargs-parser 21.1.1 (#455)
Switched to a new branch 'fix.deno'
Branch 'fix.deno' set up to track remote branch 'fix.deno' from 'origin'.

$ deno run -r deno.ts
```