### PR TITLE
Fixed webpack compile warning

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -41,7 +41,7 @@ const parser = new YargsParser({
   // we can exercise all the lines below:
   require: (path: string) => {
     if (typeof require !== 'undefined') {
-      return require(path)
+      return require(`${path}`);
     } else if (path.match(/\.json$/)) {
       // Addresses: https://github.com/yargs/yargs/issues/2040
       return JSON.parse(readFileSync(path, 'utf8'))

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -41,6 +41,7 @@ const parser = new YargsParser({
   // we can exercise all the lines below:
   require: (path: string) => {
     if (typeof require !== 'undefined') {
+  // Use string instead of var 
       return require(`${path}`);
     } else if (path.match(/\.json$/)) {
       // Addresses: https://github.com/yargs/yargs/issues/2040


### PR DESCRIPTION
Fixed issue "Critical dependency: the request of a dependency is an expression" in WebPack 4