### PR TITLE
chore: fix build:cjs run script

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "serve": "^14.0.0",
     "standardx": "^7.0.0",
     "start-server-and-test": "^1.11.2",
-    "ts-transform-default-export": "^1.0.2",
     "typescript": "^4.0.0"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "mocha": "^10.0.0",
     "puppeteer": "^16.0.0",
     "rimraf": "^3.0.2",
-    "rollup": "^2.22.1",
+    "rollup": "^3.18.0",
     "rollup-plugin-cleanup": "^3.1.1",
     "rollup-plugin-ts": "^3.0.2",
     "serve": "^14.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import cleanup from 'rollup-plugin-cleanup'
 import ts from 'rollup-plugin-ts'
-import transformDefaultExport from 'ts-transform-default-export'
 
 const output = {
   format: 'cjs',
@@ -14,11 +13,7 @@ export default {
   input: './lib/index.ts',
   output,
   plugins: [
-    ts({
-      transformers: ({ program }) => ({
-        afterDeclarations: transformDefaultExport(program)
-      })
-    }),
+    ts(),
     cleanup({
       comments: 'none',
       extensions: ['*']


### PR DESCRIPTION
The build is broken (#470), possibly by interaction of `ts-transform-default-export` and `rollup-plugin-ts`.

I tried upgrading `rollup` and failing to get the build working, stuck at new error:
```
[!] (plugin Typescript) TypeError: transformDefaultExport is not a function
```

However, `ts-transform-default-export` may no longer be required!

Installing yargs-parser (currently v21.1.1) the export in `build/build.cjs` looks like:
```
module.exports = yargsParser;
```

Removing `ts-transform-default-export`, the export in `build/build.cjs` looks as desired:
```
module.exports = yargsParser;
```

I see that rollup has a related configuration option, which we could perhaps set explicitly to reduce chance it changes in future: https://rollupjs.org/configuration-options/#output-exports

Fixes: #470

(Opening this PR as a draft since I hacked my way to a working build without deep knowledge of rollup et al. Feedback from gentle readers on things to check whether this is an adequate solution are welcome!)