### PR TITLE
chore: pin two development dependencies to fix developer build

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,12 +68,12 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.22.1",
     "rollup-plugin-cleanup": "^3.1.1",
-    "rollup-plugin-ts": "^3.0.2",
+    "rollup-plugin-ts": "3.1.1",
     "serve": "^14.0.0",
     "standardx": "^7.0.0",
     "start-server-and-test": "^1.11.2",
     "ts-transform-default-export": "^1.0.2",
-    "typescript": "^4.0.0"
+    "typescript": "4.7.4"
   },
   "files": [
     "browser.js",


### PR DESCRIPTION
This is a low-churn fix for developer build. 

- pin `rollup-plugin-ts` because it dropped node 14 in a minor version (https://github.com/wessberg/rollup-plugin-ts/issues/202)
- pin `typescript` because later versions of 4.x get an error during rollup (not sure where fault lies)

```
[!] (plugin Typescript) Error: Debug Failure. Unhandled SyntaxKind: Unknown.
Error: Debug Failure. Unhandled SyntaxKind: Unknown.
```

Fixes: #470

See also: #475

(The high-churn PR is #471 which drops `rollup-plugin-ts` and bumps minimum node version.)