### PR TITLE
fix: correctly parse unknown args with dashes when they resemble known args

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -985,7 +985,7 @@ export class YargsParser {
       // e.g. '-abc123'
       const flagEndingInDigits = /^-+([^=]+?\d+)$/
       // e.g. '-a/usr/local'
-      const flagEndingInNonWordCharacters = /^-+([^=]+?)\W+.*$/
+      const flagEndingInNonWordCharacters = /^-+([^=]+?)[^\w-]+.*$/
       // check the different types of flag styles, including negatedBoolean, a pattern defined near the start of the parse method
       return !hasFlagsMatching(arg, flagWithEquals, negatedBoolean, normalFlag, flagEndingInHyphen, flagEndingInDigits, flagEndingInNonWordCharacters)
     }

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -3194,6 +3194,103 @@ describe('yargs-parser', function () {
           k: '/1/'
         })
       })
+      // Fixes: https://github.com/yargs/yargs-parser/issues/501
+      it('should allow an unknown arg that resembles a known arg and contains hyphens to be used as the value of another flag in short form', function () {
+        {
+          const argv = parser('--known-arg /1/ -k --known-arg-unknown', {
+            string: ['k', 'known-arg'],
+            narg: { k: 1, 'known-arg': 1 },
+            configuration: {
+              'unknown-options-as-args': true
+            }
+          })
+          argv.should.deep.equal({
+            _: [],
+            k: '--known-arg-unknown',
+            'knownArg': '/1/',
+            'known-arg': '/1/',
+          })
+        }
+
+        {
+          const argv = parser('-k --u-u', {
+            string: ['k', 'u'],
+            narg: { k: 1, u: 1 },
+            configuration: {
+              'unknown-options-as-args': true
+            }
+          })
+          argv.should.deep.equal({
+            _: [],
+            k: '--u-u'
+          })
+        }
+      })
+      // Fixes: https://github.com/yargs/yargs-parser/issues/501
+      it('should allow an unknown arg that resembles a known arg and contains hyphens to be used as the value of another flag in long form', function () {
+        {
+          const argv = parser('-k /1/ --known-arg --k-u', {
+            string: ['k', 'known-arg'],
+            narg: { k: 1, 'known-arg': 1 },
+            configuration: {
+              'unknown-options-as-args': true
+            }
+          })
+          argv.should.deep.equal({
+            _: [],
+            k: '/1/',
+            'knownArg': '--k-u',
+            'known-arg': '--k-u',
+          })
+        }
+
+        {
+          const argv = parser('--known-arg --known-unknown', {
+            string: ['known-arg', 'known'],
+            narg: { 'known-arg': 1, 'known': 1 },
+            configuration: {
+              'unknown-options-as-args': true
+            }
+          })
+          argv.should.deep.equal({
+            _: [],
+            'knownArg': '--known-unknown',
+            'known-arg': '--known-unknown',
+          })
+        }
+      })
+      // Fixes: https://github.com/yargs/yargs-parser/issues/501
+      it('should allow an unknown arg that resembles a known arg and contains hyphens to be used as the value of another flag in array form', function () {
+        {
+          const argv = parser('--known-arg --known-unknown --known-not-known', {
+            array: ['known-arg', 'known'],
+            configuration: {
+              'unknown-options-as-args': true
+            }
+          })
+          argv.should.deep.equal({
+            _: [],
+            knownArg: ['--known-unknown', '--known-not-known'],
+            'known-arg': ['--known-unknown', '--known-not-known']
+          })
+        }
+
+        {
+          const argv = parser('--known-arg --k-unknown --k-not-known', {
+            array: ['known-arg'],
+            alias: { 'known-arg': ['k'] },
+            configuration: {
+              'unknown-options-as-args': true
+            }
+          })
+          argv.should.deep.equal({
+            _: [],
+            knownArg: ['--k-unknown', '--k-not-known'],
+            'known-arg': ['--k-unknown', '--k-not-known'],
+            k: ['--k-unknown', '--k-not-known']
+          })
+        }
+      })
       it('should ignore unknown options in short format with multiple flags in one argument where an unknown flag is before the end', function () {
         const argv = parser('-kuv', {
           boolean: ['k', 'v'],


### PR DESCRIPTION
Resolves #501

Additionally, to compile yargs-parser and pass the CJS unit tests, I had to make two changes I did not include in this PR:

1. Upgrade to `typescript@5` and add `--noCheck` to the "compile" and "pretest" scripts in `package.json` to work around some benign? unrelated type issues elsewhere in the codebase:

```diff
"scripts": {
...
-    "pretest": "rimraf build && tsc -p tsconfig.test.json && cross-env NODE_ENV=test npm run build:cjs",
+    "pretest": "rimraf build && tsc --noCheck -p tsconfig.test.json && cross-env NODE_ENV=test npm run build:cjs",
...
-    "compile": "tsc",
+    "compile": "tsc --noCheck",
...
  },
...
"devDependencies": {
...
-    "typescript": "^4.0.0"
+    "typescript": "^5.8.2"
  },
```

2. Remove `transformDefaultExport`-related configuration from `rollup.config.js` since the package seems to be non-functional; I don't believe the transform is required by non-EOL JS runtimes anyway:

```diff
import cleanup from 'rollup-plugin-cleanup'
import ts from 'rollup-plugin-ts'
- import transformDefaultExport from 'ts-transform-default-export'

const output = {
  format: 'cjs',
  file: './build/index.cjs',
  exports: 'default'
}

if (process.env.NODE_ENV === 'test') output.sourcemap = true

export default {
  input: './lib/index.ts',
  output,
  plugins: [
-    ts({
-      transformers: ({ program }) => ({
-        afterDeclarations: transformDefaultExport(program)
-      })
-    }),
+    ts(),
    cleanup({
      comments: 'none',
      extensions: ['*']
    })
  ]
}
```