### PR TITLE
fix: remove broken and unnecessary regexp used by unknown-options-as-args

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -981,13 +981,7 @@ export class YargsParser {
       // e.g. '-a' or '--arg'
       const normalFlag = /^-+([^=]+?)$/
       // e.g. '-a-'
-      const flagEndingInHyphen = /^-+([^=]+?)-$/
-      // e.g. '-abc123'
-      const flagEndingInDigits = /^-+([^=]+?\d+)$/
-      // e.g. '-a/usr/local'
-      const flagEndingInNonWordCharacters = /^-+([^=]+?)\W+.*$/
-      // check the different types of flag styles, including negatedBoolean, a pattern defined near the start of the parse method
-      return !hasFlagsMatching(arg, flagWithEquals, negatedBoolean, normalFlag, flagEndingInHyphen, flagEndingInDigits, flagEndingInNonWordCharacters)
+      return !hasFlagsMatching(arg, flagWithEquals, negatedBoolean, normalFlag)
     }
 
     // make a best effort to pick a default value

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -3182,6 +3182,19 @@ describe('yargs-parser', function () {
           k: 1
         })
       })
+      it('should ignore unknown options in short format followed by a dash character', function () {
+        // Somewhat redundant test since '-' is a non-word character (see next test) but '-' has own code in parser.
+        const argv = parser('-k- -u-', {
+          string: ['k'],
+          configuration: {
+            'unknown-options-as-args': true
+          }
+        })
+        argv.should.deep.equal({
+          _: ['-u-'],
+          k: '-'
+        })
+      })
       it('should ignore unknown options in short format followed by a non-word character', function () {
         const argv = parser('-k/1/ -u/2/', {
           string: ['k'],
@@ -3217,6 +3230,103 @@ describe('yargs-parser', function () {
           k: true,
           v: true
         })
+      })
+          // Fixes: https://github.com/yargs/yargs-parser/issues/501
+      it('should allow an unknown arg that resembles a known arg and contains hyphens to be used as the value of another flag in short form', function () {
+         {
+           const argv = parser('--known-arg /1/ -k --known-arg-unknown', {
+             string: ['k', 'known-arg'],
+             narg: { k: 1, 'known-arg': 1 },
+             configuration: {
+               'unknown-options-as-args': true
+             }
+           })
+           argv.should.deep.equal({
+             _: [],
+             k: '--known-arg-unknown',
+             'knownArg': '/1/',
+             'known-arg': '/1/',
+           })
+         }
+
+         {
+           const argv = parser('-k --u-u', {
+             string: ['k', 'u'],
+             narg: { k: 1, u: 1 },
+             configuration: {
+               'unknown-options-as-args': true
+             }
+           })
+           argv.should.deep.equal({
+             _: [],
+             k: '--u-u'
+           })
+         }
+      })
+      // Fixes: https://github.com/yargs/yargs-parser/issues/501
+      it('should allow an unknown arg that resembles a known arg and contains hyphens to be used as the value of another flag in long form', function () {
+         {
+           const argv = parser('-k /1/ --known-arg --k-u', {
+             string: ['k', 'known-arg'],
+             narg: { k: 1, 'known-arg': 1 },
+             configuration: {
+               'unknown-options-as-args': true
+             }
+           })
+           argv.should.deep.equal({
+             _: [],
+             k: '/1/',
+             'knownArg': '--k-u',
+             'known-arg': '--k-u',
+           })
+         }
+
+         {
+           const argv = parser('--known-arg --known-unknown', {
+             string: ['known-arg', 'known'],
+             narg: { 'known-arg': 1, 'known': 1 },
+             configuration: {
+               'unknown-options-as-args': true
+             }
+           })
+           argv.should.deep.equal({
+             _: [],
+             'knownArg': '--known-unknown',
+             'known-arg': '--known-unknown',
+           })
+         }
+      })
+      // Fixes: https://github.com/yargs/yargs-parser/issues/501
+      it('should allow an unknown arg that resembles a known arg and contains hyphens to be used as the value of another flag in array form', function () {
+         {
+           const argv = parser('--known-arg --known-unknown --known-not-known', {
+             array: ['known-arg', 'known'],
+             configuration: {
+               'unknown-options-as-args': true
+             }
+           })
+           argv.should.deep.equal({
+             _: [],
+             knownArg: ['--known-unknown', '--known-not-known'],
+             'known-arg': ['--known-unknown', '--known-not-known']
+           })
+         }
+
+         {
+           const argv = parser('--known-arg --k-unknown --k-not-known', {
+             array: ['known-arg'],
+             alias: { 'known-arg': ['k'] },
+             configuration: {
+               'unknown-options-as-args': true
+             }
+           })
+           argv.should.deep.equal({
+             _: [],
+             knownArg: ['--k-unknown', '--k-not-known'],
+             'known-arg': ['--k-unknown', '--k-not-known'],
+             k: ['--k-unknown', '--k-not-known']
+           })
+         }
       })
       it('should parse negative numbers', function () {
         const argv = parser('-k -33', {


### PR DESCRIPTION
`isUnknownOption` contained three similar regular expressions about characters after a flag. After investigation, and consistent with the examples in the comments, I believe they are related to short option group processing (so the `-+` at start of pattern is too permissive). But in fact they are not needed at all, because the cases are covered by `hasAllShortFlags()`! (I suspect the regexp predate `hasAllShortFlags` in the code evolution, but didn't confirm that.)

```javascript
      // e.g. '-a-'
      const flagEndingInHyphen = /^-+([^=]+?)-$/
      // e.g. '-abc123'
      const flagEndingInDigits = /^-+([^=]+?\d+)$/
      // e.g. '-a/usr/local'
      const flagEndingInNonWordCharacters = /^-+([^=]+?)\W+.*$/
```

After deleting the expressions all the existing tests still pass. Also fixes #501. I have copied across the tests from #502 and added @Xunnamius as a co-author on this PR.

Resolves #501
Closes #502