### PR TITLE
fix: unknown-options-as-args should treat negated boolean as unknown when boolean-negation:false

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -981,7 +981,10 @@ export class YargsParser {
       // e.g. '-a' or '--arg'
       const normalFlag = /^-+([^=]+?)$/
       // check the different types of flag styles, including negatedBoolean, a pattern defined near the start of the parse method
-      return !hasFlagsMatching(arg, flagWithEquals, negatedBoolean, normalFlag)
+      const patterns = [flagWithEquals, normalFlag];
+      if (configuration['boolean-negation'])
+        patterns.push(negatedBoolean);
+      return !hasFlagsMatching(arg, ...patterns)
     }
 
     // make a best effort to pick a default value

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -3071,6 +3071,18 @@ describe('yargs-parser', function () {
           knownArg: false
         })
       })
+      it('should ignore negated known options when boolean-negation:false', function () {
+        const argv = parser('--no-known-arg --no-unknown-arg', {
+          boolean: ['known-arg'],
+          configuration: {
+            'unknown-options-as-args': true,
+            'boolean-negation': false
+          }
+        })
+        argv.should.deep.equal({
+          _: ['--no-known-arg', '--no-unknown-arg']
+        })
+      })
       it('should ignore unknown options in long format separated by space', function () {
         const argv = parser('--known-arg a --unknown-arg b', {
           string: ['known-arg'],


### PR DESCRIPTION
The code for `isUnknownOption` was not taking configuration `boolean-negation` into account.

Fixes #376

Note: this code touches same lines as #508, and will need updating when that lands. [Edit: done]