### PR TITLE
fix: unknown-options-as-args now respects short-option-groups

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -975,7 +975,7 @@ export class YargsParser {
       // ignore negative numbers
       if (arg.match(negative)) { return false }
       // if this is a short option group and all of them are configured, it isn't unknown
-      if (hasAllShortFlags(arg)) { return false }
+      if (configuration['short-option-groups'] && hasAllShortFlags(arg)) { return false }
       // e.g. '--count=2'
       const flagWithEquals = /^-+([^=]+?)=[\s\S]*$/
       // e.g. '-a' or '--arg'

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -3249,7 +3249,7 @@ describe('yargs-parser', function () {
           v: true
         })
       })
-          // Fixes: https://github.com/yargs/yargs-parser/issues/501
+      // Fixes: https://github.com/yargs/yargs-parser/issues/501
       it('should allow an unknown arg that resembles a known arg and contains hyphens to be used as the value of another flag in short form', function () {
          {
            const argv = parser('--known-arg /1/ -k --known-arg-unknown', {
@@ -3345,6 +3345,18 @@ describe('yargs-parser', function () {
              k: ['--k-unknown', '--k-not-known']
            })
          }
+      })
+      it('should not parse known short option groups when short-option-groups:false', function () {
+        const argv = parser('-known', {
+          boolean: ['k', 'n', 'o', 'w', 'n'],
+          configuration: {
+            'unknown-options-as-args': true,
+            'short-option-groups': false
+          }
+        })
+        argv.should.deep.equal({
+          _: ['-known']
+        })
       })
       it('should parse negative numbers', function () {
         const argv = parser('-k -33', {


### PR DESCRIPTION
`isUnknownOption` was not checking `short-option-groups` before looking for short option groups. Noticed by code inspection while reviewing past and present `unknown-options-as-args` issues and code.

For amusement. Despite what you might expect, not a fix for #312.