### PR TITLE
fix: preserve negative number handling when short-option-groups:false

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -259,7 +259,7 @@ export class YargsParser {
 
       // -- separated by space.
       } else if (arg.match(/^--.+/) || (
-        !configuration['short-option-groups'] && arg.match(/^-[^-]+/)
+        !configuration['short-option-groups'] && arg.match(/^-[^-]+/) && !arg.match(negative)
       )) {
         m = arg.match(/^--?(.+)/)
         if (m !== null && Array.isArray(m) && m.length >= 2) {

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -2884,6 +2884,24 @@ describe('yargs-parser', function () {
         result.newAliases.should.deep.equal({})
       })
 
+      it('should treat negative numbers as numbers when "short-option-groups" false', function () {
+        // First confirm the normal behaviour, as that is what we expect, and has changed over time.
+        const normalResult = parser.detailed([
+          '-1'
+        ])
+        normalResult.argv.should.deep.equal({ _: [-1] })
+
+        const result = parser.detailed([
+          '-1'
+        ], {
+          configuration: {
+            'short-option-groups': false
+          }
+        })
+        result.argv.should.deep.equal({ _: [-1] })
+      })
+
+
       it('should populate the "--" if populate-- is "true"', function () {
         const result = parser([
           '--name=meowmers', 'bare', '-cats', 'woo', 'moxy',


### PR DESCRIPTION
Turning off `short-options-groups` makes `-1` get parsed as an option instead of a negative number. Add the same exclusion for negative numbers as on other code paths through parser.

Fixes #312