### PR TITLE
docs: remove greedy arrays note

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,8 +346,6 @@ $ node example --arr 1 2
 { _: [2], arr: [1] }
 ```
 
-**Note: in `v18.0.0` we are considering defaulting greedy arrays to `false`.**
-
 ### nargs eats options
 
 * default: `false`


### PR DESCRIPTION
Feel free to close if I missed something and it was changed, but as far as I can tell, the default wasn't changed in version 18. So, I removed the note.