### PR TITLE
docs: remove greedy arrays note

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ $ node example --arr 1 2
 { _: [2], arr: [1] }
 ```
 
-**Note: in `v18.0.0` we are considering defaulting greedy arrays to `false`.**
+**Note: in `v19.0.0` we are considering defaulting greedy arrays to `false`.**
 
 ### nargs eats options
 

--- a/README.md
+++ b/README.md
@@ -346,8 +346,6 @@ $ node example --arr 1 2
 { _: [2], arr: [1] }
 ```
 
-**Note: in `v19.0.0` we are considering defaulting greedy arrays to `false`.**
-
 ### nargs eats options
 
 * default: `false`


### PR DESCRIPTION
As per https://github.com/yargs/yargs-parser/pull/515#issuecomment-3256844212, update the note to say that the possible change might be in v19 instead of v18.