### PR TITLE
fix(setKey): use a sentinel to detect count auto-increment

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -620,13 +620,13 @@ export class YargsParser {
         if (typeof val === 'string') val = val === 'true'
       }
 
-      let value = Array.isArray(val)
+      let value: any = Array.isArray(val)
         ? val.map(function (v) { return maybeCoerceNumber(key, v) })
         : maybeCoerceNumber(key, val)
 
       // increment a count given as arg (either no value or value parsed as boolean)
       if (checkAllAliases(key, flags.counts) && (isUndefined(value) || typeof value === 'boolean')) {
-        value = increment()
+        value = INCREMENT_SENTINEL
       }
 
       // Set normalized value when key is in 'normalize' and in 'arrays'
@@ -850,7 +850,7 @@ export class YargsParser {
         }
       }
 
-      if (value === increment()) {
+      if (value === INCREMENT_SENTINEL) {
         o[key] = increment(o[key])
       } else if (Array.isArray(o[key])) {
         if (duplicate && isTypeArray && isValueArray) {
@@ -1097,6 +1097,8 @@ function combineAliases (aliases: Dictionary<string | string[]>): Dictionary<str
 
   return combined
 }
+
+const INCREMENT_SENTINEL = Symbol('count-increment')
 
 // this function should only be called when a count is given as an arg
 // it is NOT called to set a default value

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -2581,6 +2581,10 @@ describe('yargs-parser', function () {
 
         parsed.x.should.deep.equal(['o', 'p', 'q'])
       })
+      it('does not sum repeated numeric arguments when one equals 1', function () {
+        const parsed = parser('-x 3 -x 1')
+        parsed.x.should.deep.equal([3, 1])
+      })
     })
 
     describe('flatten duplicate arrays', function () {


### PR DESCRIPTION
The TypeScript conversion changed `value === increment` (function reference used as a sentinel) to `value === increment()` (which returns `1`), so any later occurrence of a non-count argument with value `1` is incorrectly incremented onto the previous value (`parser('-x 3 -x 1')` returns `{ x: 4 }` instead of `{ x: [3, 1] }`). Restored the original semantics with a `Symbol` sentinel that flows from `processValue` to `setKey`.

Closes #506