### PR TITLE
fix: array type flags (number/boolean/string) should respect their value

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -115,14 +115,17 @@ export class YargsParser {
       const key = typeof opt === 'object' ? opt.key : opt
 
       // assign to flags[bools|strings|numbers]
-      const assignment: ArrayFlagsKey | undefined = Object.keys(opt).map(function (key) {
-        const arrayFlagKeys: Record<string, ArrayFlagsKey> = {
-          boolean: 'bools',
-          string: 'strings',
-          number: 'numbers'
-        }
-        return arrayFlagKeys[key]
-      }).filter(Boolean).pop()
+      const arrayFlagKeys: Record<string, ArrayFlagsKey> = {
+        boolean: 'bools',
+        string: 'strings',
+        number: 'numbers'
+      }
+      const assignment: ArrayFlagsKey | undefined = typeof opt === 'object'
+        ? Object.keys(arrayFlagKeys)
+          .filter((flagKey) => (opt as Record<string, unknown>)[flagKey] === true)
+          .map((flagKey) => arrayFlagKeys[flagKey])
+          .pop()
+        : undefined
 
       // assign key to be coerced
       if (assignment) {

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -1877,6 +1877,37 @@ describe('yargs-parser', function () {
       result.should.have.property('x').that.is.an('array').and.to.deep.equal(['5', '2'])
     })
 
+    // see https://github.com/yargs/yargs-parser/issues/415
+    // a falsy type flag should be treated as if it were absent, rather than
+    // enabling the corresponding coercion.
+    it('should not coerce array values to number when `number` is false', function () {
+      const result = parser(['--foo', 'dog', 'cat'], {
+        array: [{ key: 'foo', number: false }]
+      })
+      result.should.have.property('foo').that.is.an('array').and.to.deep.equal(['dog', 'cat'])
+    })
+
+    it('should not coerce array values to number when `number` is undefined', function () {
+      const result = parser(['--foo', 'dog', 'cat'], {
+        array: [{ key: 'foo', number: undefined }]
+      })
+      result.should.have.property('foo').that.is.an('array').and.to.deep.equal(['dog', 'cat'])
+    })
+
+    it('should not coerce array values to boolean when `boolean` is false', function () {
+      const result = parser(['--foo', 'dog', 'cat'], {
+        array: [{ key: 'foo', boolean: false }]
+      })
+      result.should.have.property('foo').that.is.an('array').and.to.deep.equal(['dog', 'cat'])
+    })
+
+    it('should not coerce array values to string when `string` is false', function () {
+      const result = parser(['--foo', '1', '2'], {
+        array: [{ key: 'foo', string: false }]
+      })
+      result.should.have.property('foo').that.is.an('array').and.to.deep.equal([1, 2])
+    })
+
     it('should eat non-hyphenated arguments until hyphenated option is hit - combined with coercion', function () {
       const result = parser([
         '-a=hello', 'world',


### PR DESCRIPTION
Fixes #415.

## Problem

When an `array` option is configured with an object, the parser decides whether to coerce its values to `number`/`boolean`/`string` based on the **presence** of the corresponding key, ignoring its value. As a result a *falsy* type flag still enables coercion:

```js
const parser = require("yargs-parser")

parser("--foo dog cat", { array: { key: "foo", number: false } })
// actual:   { _: [], foo: [ null, null ] }   (NaN on older versions)
// expected: { _: [], foo: [ "dog", "cat" ] }

parser("--foo dog cat", { array: { key: "foo", number: undefined } })
// same wrong result
```

The README documents enabling coercion with `number: true`, and the type definition declares these properties as `boolean?`, so `false`/`undefined` should behave as if the flag were absent. The same bug affects `boolean: false` (values wrongly coerced to booleans) and `string: false` (numbers wrongly kept as strings).

## Cause

In `lib/yargs-parser.ts`, the assignment was derived from `Object.keys(opt)`, which only checks key existence:

```js
const assignment = Object.keys(opt).map(function (key) {
  const arrayFlagKeys = { boolean: "bools", string: "strings", number: "numbers" }
  return arrayFlagKeys[key]
}).filter(Boolean).pop()
```

## Fix

Only enable a coercion flag when its value is strictly `=== true`. (Also guards the object-vs-string `opt` case explicitly, instead of relying on a string`s numeric character indices never matching a flag name.)

## Tests

Added four tests covering `number: false`, `number: undefined`, `boolean: false`, and `string: false`. All four fail on `main` and pass with the fix; the full suite (`npm test`) stays green (366 passing) with 100% coverage on `yargs-parser.ts`, and `npm run check` (gts lint) is clean.