### PR TITLE
test: add regression for non-count option with value 1

### DIFF
--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -1529,6 +1529,13 @@ describe('yargs-parser', function () {
     })
   })
 
+
+  it('should not increment non-count options when value equals 1', function () {
+    const result = parser('-x 3 -x 1')
+    result.should.have.property('x')
+    result.x.should.eql([3, 1])
+  })
+
   describe('count', function () {
     it('should count the number of times a boolean is present', function () {
       let parsed


### PR DESCRIPTION
## What changed
Added a regression test for non-count options that receive a value of `1`.

## Why
When passing `-x 3 -x 1`, the parser incorrectly treats the `1` as a count increment, returning `x: 4` instead of `x: [3, 1]`. The root cause is in `setKey()` where `value === increment()` (which is `1`) gates the increment logic, incorrectly matching actual values of `1`.

## Verification
```
parser("-x 3 -x 1")
// Expected: x: [3, 1]
// Actual:   x: 4  ← bug: 3 + 1 = 4
```
The test currently fails as expected.

## Related issue
Refs #506