### PR TITLE
fix: array sub-type option respects its value, not just its presence (#415)

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -121,7 +121,11 @@ export class YargsParser {
           string: 'strings',
           number: 'numbers'
         }
-        return arrayFlagKeys[key]
+        // Only enable the sub-type coercion when its value is truthy, so an
+        // explicit falsy value such as `{ number: false }` is ignored (#415).
+        return typeof opt === 'object' && (opt as Record<string, unknown>)[key]
+          ? arrayFlagKeys[key]
+          : undefined
       }).filter(Boolean).pop()
 
       // assign key to be coerced

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -1867,6 +1867,13 @@ describe('yargs-parser', function () {
       result.should.have.property('x').that.is.an('array').and.to.deep.equal([5, 2])
     })
 
+    it('should not coerce array values as numbers when `number` is false (#415)', function () {
+      const result = parser(['--foo', 'dog', 'cat'], {
+        array: [{ key: 'foo', number: false }]
+      })
+      result.should.have.property('foo').that.deep.equals(['dog', 'cat'])
+    })
+
     it('should respect the type `string` option for arrays', function () {
       const result = parser(['-x=5', '2'], {
         configuration: {


### PR DESCRIPTION
## Fixes #415

An `array` option configured with a **falsy** sub-type flag still enabled that coercion. For example, `{ key: 'foo', number: false }` coerced the array values as numbers:

```js
const parser = require('yargs-parser')

parser('--foo dog cat', { array: { key: 'foo', number: false } })
// before: { _: [], foo: [ NaN, NaN ] }
// after:  { _: [], foo: [ 'dog', 'cat' ] }

parser('--foo dog cat', { array: { key: 'foo', number: undefined } })
// before: { _: [], foo: [ NaN, NaN ] }
// after:  { _: [], foo: [ 'dog', 'cat' ] }
```

## Root cause

When registering array options, the sub-type (`boolean` / `string` / `number`) was selected by **key existence** rather than by **value**:

```ts
const assignment = Object.keys(opt).map(function (key) {
  const arrayFlagKeys = { boolean: 'bools', string: 'strings', number: 'numbers' }
  return arrayFlagKeys[key]          // <- fires whenever the key is present
}).filter(Boolean).pop()
```

So `{ number: false }` (or `undefined`) still mapped to `'numbers'` and turned on number coercion.

## Fix

Only enable the sub-type coercion when its value is truthy:

```ts
return typeof opt === 'object' && (opt as Record<string, unknown>)[key]
  ? arrayFlagKeys[key]
  : undefined
```

`{ number: true }` / `{ string: true }` / `{ boolean: true }` are unchanged; only explicit falsy values now behave as "not set".

## Tests

Added a regression test (`should not coerce array values as numbers when 'number' is false (#415)`) using non-numeric values, since numeric-looking strings are coerced by the global `parse-numbers` default regardless of this flag.

Verified locally: full suite **363 passing** (1 new), `gts lint` clean.
