### PR TITLE
fix: parse short option with trailing equals and empty value (-o=) as empty string

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -318,7 +318,7 @@ export class YargsParser {
         for (let j = 0; j < letters.length; j++) {
           next = arg.slice(j + 2)
 
-          if (letters[j + 1] && letters[j + 1] === '=') {
+          if ((letters[j + 1] && letters[j + 1] === '=') || next === '=') {
             value = arg.slice(j + 3)
             key = letters[j]
 

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -186,6 +186,13 @@ describe('yargs-parser', function () {
     parse.should.have.property('_').with.length(0)
   })
 
+  // Addresses: https://github.com/yargs/yargs-parser/issues/367
+  it('should set a short option to an empty string when a trailing equals sign supplies no value', function () {
+    parser(['-o='], { alias: { o: 'opt' } }).should.deep.equal({ _: [], o: '', opt: '' })
+    // control: a non-empty value after the equals sign is unaffected
+    parser(['-o=x'], { alias: { o: 'opt' } }).should.deep.equal({ _: [], o: 'x', opt: 'x' })
+  })
+
   it('should not set the next value as the value of a short option if that option is explicitly defined as a boolean', function () {
     const parse = parser(['-t', 'moo'], {
       boolean: 't'


### PR DESCRIPTION
Fixes #367

## Problem

A short option written with a trailing `=` and no value mis-parses. The `=` is treated as a standalone key and the option becomes boolean `true`:

    parser(['-o='], { alias: { o: 'opt' } })
    // actual:   { _: [], o: true, opt: true, '=': true }
    // expected: { _: [], o: '', opt: '' }

The equivalent long option already behaves correctly, which is the tell that this is a short-option-only bug:

    parser(['--opt='])  // => { _: [], opt: '' }   (correct)

## Root cause

In the short-option branch of `lib/yargs-parser.ts`, `letters = arg.slice(1, -1).split('')` strips the trailing `=`. For `-o=` that leaves `letters = ['o']`, so the `letters[j + 1] === '='` guard never matches. Parsing falls through to `setArg('o', defaultValue('o'))` (boolean `true`) and then `key = arg.slice(-1)[0]` picks the trailing `=` up as a spurious key.

## Fix

`next` is already computed as `arg.slice(j + 2)` and equals exactly `'='` only on the final letter when the arg ends in a trailing `=`. Adding that as an alternative trigger routes `-o=` through the existing `=`-handling branch, where `value = arg.slice(j + 3)` correctly resolves to `''`:

    if ((letters[j + 1] && letters[j + 1] === '=') || next === '=') {

Non-empty values (`-o=x`) are unaffected -- they still match the original `letters[j + 1] === '='` condition.

## Tests

Added a case next to the existing empty-value short-option test covering both `-o=` (empty) and the `-o=x` control. Full suite: 363 passing, lint clean.

---
This change was prepared with AI assistance and reviewed by the author.