### PR TITLE
Respect required args before array defaults

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -503,12 +503,14 @@ export class YargsParser {
     // e.g., --foo apple banana cat becomes ["apple", "banana", "cat"]
     function eatArray (i: number, key: string, args: string[], argAfterEqualSign?: string): number {
       let argsToSet = []
+      let argsProvided = 0
       let next = argAfterEqualSign || args[i + 1]
       // If both array and nargs are configured, enforce the nargs count:
       const nargsCount = checkAllAliases(key, flags.nargs)
 
       if (checkAllAliases(key, flags.bools) && !(/^(true|false)$/.test(next))) {
         argsToSet.push(true)
+        argsProvided++
       } else if (isUndefined(next) ||
           (isUndefined(argAfterEqualSign) && /^-/.test(next) && !negative.test(next) && !isUnknownOptionAsArg(next))) {
         // for keys without value ==> argsToSet remains an empty []
@@ -521,6 +523,7 @@ export class YargsParser {
         // value in --option=value is eaten as is
         if (!isUndefined(argAfterEqualSign)) {
           argsToSet.push(processValue(key, argAfterEqualSign, true))
+          argsProvided++
         }
         for (let ii = i + 1; ii < args.length; ii++) {
           if ((!configuration['greedy-arrays'] && argsToSet.length > 0) ||
@@ -529,14 +532,15 @@ export class YargsParser {
           if (/^-/.test(next) && !negative.test(next) && !isUnknownOptionAsArg(next)) break
           i = ii
           argsToSet.push(processValue(key, next, inputIsString))
+          argsProvided++
         }
       }
 
       // If both array and nargs are configured, create an error if less than
       // nargs positionals were found. NaN has special meaning, indicating
       // that at least one value is required (more are okay).
-      if (typeof nargsCount === 'number' && ((nargsCount && argsToSet.length < nargsCount) ||
-          (isNaN(nargsCount) && argsToSet.length === 0))) {
+      if (typeof nargsCount === 'number' && ((nargsCount && argsProvided < nargsCount) ||
+          (isNaN(nargsCount) && argsProvided === 0))) {
         error = Error(__('Not enough arguments following: %s', key))
       }
 

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -4051,6 +4051,21 @@ describe('yargs-parser', function () {
       parse.error.message.should.equal('Not enough arguments following: a')
     })
 
+    it('returns an error if only an array default is available for nargs', () => {
+      const parse = parser.detailed(['-a'], {
+        array: 'a',
+        default: {
+          a: ['default']
+        },
+        narg: {
+          a: NaN
+        }
+      })
+
+      parse.argv.a.should.eql(['default'])
+      parse.error.message.should.equal('Not enough arguments following: a')
+    })
+
     it('returns an error if not enough positionals were provided for nargs even with nargs-eats-options', () => {
       const parse = parser.detailed(['-a', '33', '--cat'], {
         narg: {


### PR DESCRIPTION
Fixes #445.

When an array option had both a default and a required argument count, the missing-value path filled in the default before `narg` validation ran. That made a default look like a user-provided value, so `-a` could pass even though yargs asked for an argument.

This keeps counting the values that actually came from argv separately from the array value we eventually assign, so defaults still apply but they no longer satisfy the required-argument check.

Tests run:
- `npx mocha test/yargs-parser.mjs --grep "array with nargs|nargs"`
- `npm run check`
- `npm test`