### PR TITLE
Let narg zero flags beat false defaults

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -465,7 +465,11 @@ export class YargsParser {
         if (!isUndefined(argAfterEqualSign)) {
           error = Error(__('Argument unexpected for: %s', key))
         }
-        setArg(key, defaultValue(key))
+        if (!checkAllAliases(key, flags.strings) && !checkAllAliases(key, flags.numbers)) {
+          setArg(key, true)
+        } else {
+          setArg(key, defaultValue(key))
+        }
         return i
       }
 

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -1941,6 +1941,29 @@ describe('yargs-parser', function () {
       argv.error.message.should.equal('Argument unexpected for: bar')
     })
 
+    it('should allow narg 0 to override a false default', function () {
+      const argv = parser('-a hello -b world', {
+        narg: {
+          a: 1,
+          b: 0
+        },
+        default: {
+          b: false
+        },
+        alias: {
+          blah: ['b', 'bl']
+        }
+      })
+
+      argv.should.deep.equal({
+        _: ['world'],
+        a: 'hello',
+        b: true,
+        bl: true,
+        blah: true
+      })
+    })
+
     it('should raise an exception if there are not enough arguments following key', function () {
       const argv = parser.detailed('--foo apple', {
         narg: {


### PR DESCRIPTION
Fixes #418.

A zero-argument option still needs to record that the flag was present. When the same option also had a `false` default, the old path reused `defaultValue(key)`, so the explicit `-b` ended up as `false` and its aliases picked up the same default.

This keeps the existing `number` and `string` behavior for `narg: 0`, but lets boolean-like zero-arg flags override the default with `true` when the user actually passes them.

Tests run:
- `npx mocha test/yargs-parser.mjs --grep "narg 0|zero narg|nargs"`
- `npm run check`
- `npm test`