### PR TITLE
Keep quotes from config values intact

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -709,7 +709,7 @@ export class YargsParser {
           // setting arguments via CLI takes precedence over
           // values within the config file.
           if (!hasKey(argv, fullKey.split('.')) || (checkAllAliases(fullKey, flags.arrays) && configuration['combine-arrays'])) {
-            setArg(fullKey, value)
+            setArg(fullKey, value, false)
           }
         }
       })

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -2,6 +2,7 @@
     "herp": "derp",
     "z": 55,
     "foo": "baz",
+    "quoted": "\"hello\"",
     "version": "1.0.2",
     "truthy": true,
     "toString": "method name",

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -517,6 +517,17 @@ describe('yargs-parser', function () {
       argv.should.have.property('foo').and.deep.equal('bar')
     })
 
+    it('should preserve quoted string values from config files', function () {
+      const argv = parser([], {
+        config: ['settings'],
+        default: {
+          settings: jsonPath
+        }
+      })
+
+      argv.should.have.property('quoted').and.equal('"hello"')
+    })
+
     it('should use value from config file, if argv value is using default value', function () {
       const argv = parser([], {
         alias: {


### PR DESCRIPTION
Fixes #385.

Config values are already parsed before they reach `setConfigObject`, but that path was still using the default `setArg` quote stripping. A value like `"hello"` from JSON therefore became `hello`, which is surprising because no shell-style string tokenization is involved there.

This passes config values through without quote stripping, while leaving argv string parsing unchanged.

Tests run:
- `npm test -- --grep "config"`
- `npm run check`
- `npm test`