### PR TITLE
Treat empty array equals as a value

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -503,7 +503,7 @@ export class YargsParser {
     // e.g., --foo apple banana cat becomes ["apple", "banana", "cat"]
     function eatArray (i: number, key: string, args: string[], argAfterEqualSign?: string): number {
       let argsToSet = []
-      let next = argAfterEqualSign || args[i + 1]
+      let next = isUndefined(argAfterEqualSign) ? args[i + 1] : argAfterEqualSign
       // If both array and nargs are configured, enforce the nargs count:
       const nargsCount = checkAllAliases(key, flags.nargs)
 

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -1712,6 +1712,13 @@ describe('yargs-parser', function () {
       result.b[0].should.equal(33)
     })
 
+    it('should place an empty equals value in an array', function () {
+      const result = parser(['--tag='], {
+        array: ['tag']
+      })
+      result.tag.should.deep.equal([''])
+    })
+
     it('should add multiple argument values to the array', function () {
       const result = parser(['-b', '33', '-b', 'hello'], {
         array: 'b'


### PR DESCRIPTION
Fixes #368.

Array parsing treated `--opt=` differently from `--opt ""` because the empty string after `=` was selected with `||`. That made it fall through as if there was no value at all, so the array became `[]`.

This keeps an explicit empty string from the equals form and stores it the same way as the space-separated form.

Tests run:
- `npm test -- --grep "array|empty equals"`
- `npm run check`
- `npm test`