### PR TITLE
Strip dashed keys inside dot notation

### DIFF
--- a/lib/yargs-parser.ts
+++ b/lib/yargs-parser.ts
@@ -429,9 +429,7 @@ export class YargsParser {
     })
 
     if (configuration['camel-case-expansion'] && configuration['strip-dashed']) {
-      Object.keys(argv).filter(key => key !== '--' && key.includes('-')).forEach(key => {
-        delete argv[key]
-      })
+      stripDashedKeys(argv)
     }
 
     if (configuration['strip-aliased']) {
@@ -450,6 +448,16 @@ export class YargsParser {
       if (typeof maybeCoercedNumber === 'string' || typeof maybeCoercedNumber === 'number') {
         argv._.push(maybeCoercedNumber)
       }
+    }
+
+    function stripDashedKeys (obj: { [key: string]: any }): void {
+      Object.keys(obj).forEach(key => {
+        if (key !== '--' && key.includes('-')) {
+          delete obj[key]
+        } else if (typeof obj[key] === 'object' && obj[key] !== null && !Array.isArray(obj[key])) {
+          stripDashedKeys(obj[key])
+        }
+      })
     }
 
     // how many arguments should we consume, based

--- a/test/yargs-parser.mjs
+++ b/test/yargs-parser.mjs
@@ -3806,6 +3806,21 @@ describe('yargs-parser', function () {
       })
     })
 
+    it('strip-dashed removes dashed fields from dot-notation values', function () {
+      const argv = parser(['--dashed-will-be-stripped', '--here.it-will-not'], {
+        configuration: {
+          'strip-dashed': true
+        }
+      })
+      argv.should.deep.equal({
+        _: [],
+        dashedWillBeStripped: true,
+        here: {
+          itWillNot: true
+        }
+      })
+    })
+
     it('strip-aliased removes expected fields from argv', function () {
       const argv = parser(['--test-value', '1'], {
         number: ['test-value'],


### PR DESCRIPTION
Fixes #223.

`strip-dashed` only looked at top-level argv keys. With dot notation, the dashed form inside a nested object stayed around next to the camel-cased key, so `--here.it-will-not` produced both `it-will-not` and `itWillNot`.

This makes the dashed-key cleanup walk nested plain objects as well, while still preserving the special `--` key.

Tests run:
- `npm test -- --grep "stripping|strip-dashed"`
- `npm run check`
- `npm test`